### PR TITLE
Add OmgBlock component for rendering API documentation blocks

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -1,6 +1,7 @@
 import { themes as prismThemes } from 'prism-react-renderer';
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+import remarkOmg from './plugins/remark-omg';
 
 const config: Config = {
   title: 'OMG',
@@ -32,6 +33,7 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/mcclowes/omg/tree/main/docusaurus/',
+          remarkPlugins: [remarkOmg],
         },
         blog: false,
         theme: {

--- a/docusaurus/plugins/remark-omg.ts
+++ b/docusaurus/plugins/remark-omg.ts
@@ -1,0 +1,135 @@
+import type { Root, Code } from 'mdast';
+import type { Plugin } from 'unified';
+
+interface MdxJsxAttribute {
+  type: 'mdxJsxAttribute';
+  name: string;
+  value: string | MdxJsxAttributeValueExpression;
+}
+
+interface MdxJsxAttributeValueExpression {
+  type: 'mdxJsxAttributeValueExpression';
+  value: string;
+  data: {
+    estree: {
+      type: 'Program';
+      body: Array<{
+        type: 'ExpressionStatement';
+        expression: {
+          type: 'Literal';
+          value: unknown;
+          raw: string;
+        };
+      }>;
+      sourceType: 'module';
+      comments: never[];
+    };
+  };
+}
+
+function makeLiteral(value: unknown): MdxJsxAttributeValueExpression {
+  return {
+    type: 'mdxJsxAttributeValueExpression',
+    value: JSON.stringify(value),
+    data: {
+      estree: {
+        type: 'Program',
+        body: [
+          {
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'Literal',
+              value,
+              raw: JSON.stringify(value),
+            },
+          },
+        ],
+        sourceType: 'module',
+        comments: [],
+      },
+    },
+  };
+}
+
+const remarkOmg: Plugin<[], Root> = () => {
+  return async (ast) => {
+    const { visit } = await import('unist-util-visit');
+
+    visit(ast, 'code', (node: Code, index, parent) => {
+      if (!node.lang || !node.lang.startsWith('omg.')) return;
+      if (parent === undefined || index === undefined) return;
+
+      let blockType = node.lang;
+      const source = node.value;
+      const meta = node.meta || '';
+
+      // Extract status code: omg.response.201 -> blockType=omg.response, statusCode=201
+      let statusCode: number | undefined;
+      const codeMatch = blockType.match(/^(omg\.(?:response|example))\.(\d{3})$/);
+      if (codeMatch) {
+        blockType = codeMatch[1];
+        statusCode = parseInt(codeMatch[2], 10);
+      }
+
+      // Extract example name: omg.example.success -> exampleName=success
+      let exampleName: string | undefined;
+      if (!codeMatch) {
+        const nameMatch = blockType.match(/^(omg\.example)\.(\w+)$/);
+        if (nameMatch) {
+          blockType = nameMatch[1];
+          exampleName = nameMatch[2];
+        }
+      }
+
+      // Extract @when condition from meta string
+      let whenCondition: string | undefined;
+      const whenMatch = meta.match(/@when\((.+?)\)/);
+      if (whenMatch) {
+        whenCondition = whenMatch[1];
+      }
+
+      // Build mdxJsxFlowElement attributes
+      const attributes: MdxJsxAttribute[] = [
+        { type: 'mdxJsxAttribute', name: 'blockType', value: blockType },
+        {
+          type: 'mdxJsxAttribute',
+          name: 'source',
+          value: makeLiteral(source),
+        },
+      ];
+
+      if (statusCode !== undefined) {
+        attributes.push({
+          type: 'mdxJsxAttribute',
+          name: 'statusCode',
+          value: makeLiteral(statusCode),
+        });
+      }
+      if (exampleName) {
+        attributes.push({
+          type: 'mdxJsxAttribute',
+          name: 'exampleName',
+          value: exampleName,
+        });
+      }
+      if (whenCondition) {
+        attributes.push({
+          type: 'mdxJsxAttribute',
+          name: 'whenCondition',
+          value: whenCondition,
+        });
+      }
+
+      // Replace the code node with an MDX JSX element
+      (parent.children as any[])[index] = {
+        type: 'mdxJsxFlowElement',
+        name: 'OmgBlock',
+        attributes,
+        children: [],
+        data: { _mdxExplicitJsx: true },
+      };
+    });
+  };
+};
+
+export default remarkOmg;

--- a/docusaurus/src/components/OmgBlock/index.tsx
+++ b/docusaurus/src/components/OmgBlock/index.tsx
@@ -1,0 +1,364 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+interface OmgBlockProps {
+  blockType: string;
+  source: string;
+  statusCode?: number;
+  exampleName?: string;
+  whenCondition?: string;
+}
+
+interface ParsedField {
+  name: string;
+  type: string;
+  required: boolean;
+  annotations: string[];
+  description: string;
+}
+
+interface ParsedReturn {
+  statusCode: number;
+  type: string;
+  condition?: string;
+  description?: string;
+}
+
+// --- Labels & helpers ---
+
+const BLOCK_LABELS: Record<string, string> = {
+  'omg.path': 'Path Parameters',
+  'omg.query': 'Query Parameters',
+  'omg.headers': 'Headers',
+  'omg.body': 'Request Body',
+  'omg.response': 'Response',
+  'omg.returns': 'Returns',
+  'omg.example': 'Example',
+  'omg.type': 'Type',
+  'omg.errors': 'Error Responses',
+  'omg.config': 'Configuration',
+};
+
+function getLabel(
+  blockType: string,
+  source: string,
+  statusCode?: number,
+  exampleName?: string
+): string {
+  let label = BLOCK_LABELS[blockType] || blockType;
+
+  if (blockType === 'omg.response') {
+    label = `Response \u00b7 ${statusCode ?? 200}`;
+  } else if (blockType === 'omg.type') {
+    const match = source.match(/^type\s+(\w+)/);
+    if (match) label = `Type \u00b7 ${match[1]}`;
+  } else if (blockType === 'omg.example') {
+    if (exampleName) label = `Example \u00b7 ${exampleName}`;
+    else if (statusCode) label = `Example \u00b7 ${statusCode}`;
+  }
+
+  return label;
+}
+
+function getStatusClass(code: number): string {
+  if (code < 300) return styles.statusSuccess;
+  if (code < 400) return styles.statusRedirect;
+  if (code < 500) return styles.statusClientError;
+  return styles.statusServerError;
+}
+
+// --- Lightweight parsers ---
+
+function parseFields(source: string): ParsedField[] | null {
+  const trimmed = source.trim();
+  if (!trimmed.startsWith('{')) return null;
+
+  // Find matching closing brace at depth 0
+  let depth = 0;
+  let end = -1;
+  for (let i = 0; i < trimmed.length; i++) {
+    if (trimmed[i] === '{') depth++;
+    if (trimmed[i] === '}') {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) return null;
+
+  const inner = trimmed.slice(1, end);
+  const fields: ParsedField[] = [];
+
+  // Walk character-by-character, splitting on newlines only at brace depth 0
+  let braceDepth = 0;
+  let currentLine = '';
+
+  for (const ch of inner) {
+    if (ch === '{') braceDepth++;
+    if (ch === '}') braceDepth--;
+    if (ch === '\n' && braceDepth === 0) {
+      processFieldLine(currentLine, fields);
+      currentLine = '';
+    } else {
+      currentLine += ch;
+    }
+  }
+  if (currentLine.trim()) processFieldLine(currentLine, fields);
+
+  return fields.length > 0 ? fields : null;
+}
+
+function processFieldLine(line: string, fields: ParsedField[]): void {
+  const stripped = line.trim();
+  if (!stripped || stripped.startsWith('//')) return;
+
+  // Extract inline comment (// ...) not inside a string
+  let description = '';
+  let content = stripped;
+  let inStr = false;
+  let strChar = '';
+
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i];
+    if (inStr) {
+      if (ch === strChar && content[i - 1] !== '\\') inStr = false;
+    } else if (ch === '"' || ch === "'") {
+      inStr = true;
+      strChar = ch;
+    } else if (ch === '/' && content[i + 1] === '/') {
+      description = content.slice(i + 2).trim();
+      content = content.slice(0, i).trim();
+      break;
+    }
+  }
+
+  // Remove trailing comma
+  content = content.replace(/,\s*$/, '').trim();
+  if (!content) return;
+
+  // Find first colon not inside braces/brackets
+  let colonIdx = -1;
+  let d = 0;
+  let bk = 0;
+  for (let i = 0; i < content.length; i++) {
+    if (content[i] === '{') d++;
+    if (content[i] === '}') d--;
+    if (content[i] === '[') bk++;
+    if (content[i] === ']') bk--;
+    if (content[i] === ':' && d === 0 && bk === 0) {
+      colonIdx = i;
+      break;
+    }
+  }
+  if (colonIdx === -1) return;
+
+  let name = content.slice(0, colonIdx).trim();
+  let rest = content.slice(colonIdx + 1).trim();
+
+  // Optional marker on name
+  let required = true;
+  if (name.endsWith('?')) {
+    name = name.slice(0, -1).trim();
+    required = false;
+  }
+
+  // Extract annotations (@min(1), @format("email"), etc.)
+  const annotations: string[] = [];
+  const annotRe = /@\w+(?:\([^)]*\))?/g;
+  let m: RegExpExecArray | null;
+  while ((m = annotRe.exec(rest)) !== null) {
+    annotations.push(m[0]);
+  }
+  let type = rest.replace(annotRe, '').trim();
+
+  // Check for default value (= ...)
+  const eqMatch = type.match(/\s*=\s*(.+)$/);
+  if (eqMatch) {
+    type = type.slice(0, eqMatch.index).trim();
+    required = false;
+  }
+
+  // Optional marker on type
+  if (type.endsWith('?')) {
+    type = type.slice(0, -1).trim();
+    required = false;
+  }
+
+  // Clean up whitespace
+  type = type.replace(/\s+/g, ' ').trim();
+
+  fields.push({ name, type, required, annotations, description });
+}
+
+function parseReturns(source: string): ParsedReturn[] {
+  const returns: ParsedReturn[] = [];
+  const lines = source.split('\n');
+  let current: ParsedReturn | null = null;
+
+  for (const line of lines) {
+    const stripped = line.trim();
+    if (!stripped) continue;
+
+    const statusMatch = stripped.match(/^(\d{3}):\s*(.+)$/);
+    if (statusMatch) {
+      if (current) returns.push(current);
+      current = {
+        statusCode: parseInt(statusMatch[1], 10),
+        type: statusMatch[2].trim(),
+      };
+      continue;
+    }
+
+    if (!current) continue;
+
+    const whenMatch = stripped.match(/^when\s+(.+)$/);
+    if (whenMatch) {
+      current.condition = whenMatch[1];
+      continue;
+    }
+
+    const descMatch = stripped.match(/^"(.+)"$/);
+    if (descMatch) {
+      current.description = descMatch[1];
+    }
+  }
+
+  if (current) returns.push(current);
+  return returns;
+}
+
+// --- Sub-components ---
+
+function FieldsTable({ fields }: { fields: ParsedField[] }) {
+  return (
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th></th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {fields.map((field) => (
+          <tr key={field.name}>
+            <td className={styles.fieldName}>
+              <code>{field.name}</code>
+            </td>
+            <td className={styles.fieldType}>
+              <code>{field.type}</code>
+              {field.annotations.length > 0 && (
+                <span className={styles.annotations}>
+                  {field.annotations.map((a, i) => (
+                    <code key={i} className={styles.annotation}>
+                      {a}
+                    </code>
+                  ))}
+                </span>
+              )}
+            </td>
+            <td className={styles.fieldRequired}>
+              {field.required ? (
+                <span className={styles.requiredBadge}>required</span>
+              ) : (
+                <span className={styles.optionalBadge}>optional</span>
+              )}
+            </td>
+            <td className={styles.fieldDescription}>{field.description}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function ReturnsList({ returns }: { returns: ParsedReturn[] }) {
+  return (
+    <div className={styles.returnsList}>
+      {returns.map((r) => (
+        <div key={r.statusCode} className={styles.returnEntry}>
+          <span className={`${styles.statusCode} ${getStatusClass(r.statusCode)}`}>
+            {r.statusCode}
+          </span>
+          <div className={styles.returnContent}>
+            <code className={styles.returnType}>{r.type}</code>
+            {r.condition && (
+              <div className={styles.condition}>
+                <span className={styles.conditionKeyword}>when</span> {r.condition}
+              </div>
+            )}
+            {r.description && <div className={styles.returnDescription}>{r.description}</div>}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SourceView({ source }: { source: string }) {
+  return (
+    <pre className={styles.sourceBlock}>
+      <code>{source}</code>
+    </pre>
+  );
+}
+
+// --- Main component ---
+
+export default function OmgBlock({
+  blockType,
+  source,
+  statusCode,
+  exampleName,
+  whenCondition,
+}: OmgBlockProps): React.ReactElement {
+  const label = getLabel(blockType, source, statusCode, exampleName);
+
+  // Parse based on block type
+  const schemaBlockTypes = ['omg.path', 'omg.query', 'omg.headers', 'omg.body', 'omg.response'];
+
+  let fields: ParsedField[] | null = null;
+  let returns: ParsedReturn[] | null = null;
+
+  if (schemaBlockTypes.includes(blockType)) {
+    fields = parseFields(source);
+  } else if (blockType === 'omg.type') {
+    const bodyMatch = source.match(/^type\s+\w+\s*(\{[\s\S]*\})\s*$/);
+    if (bodyMatch) fields = parseFields(bodyMatch[1]);
+  } else if (blockType === 'omg.returns') {
+    returns = parseReturns(source);
+  }
+
+  const hasStructuredView = fields || (returns && returns.length > 0);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <span className={styles.label}>{label}</span>
+        {whenCondition && <span className={styles.whenBadge}>@when({whenCondition})</span>}
+      </div>
+
+      <div className={styles.body}>
+        {fields ? (
+          <FieldsTable fields={fields} />
+        ) : returns && returns.length > 0 ? (
+          <ReturnsList returns={returns} />
+        ) : (
+          <SourceView source={source} />
+        )}
+      </div>
+
+      {hasStructuredView && (
+        <details className={styles.sourceDetails}>
+          <summary className={styles.sourceSummary}>View source</summary>
+          <pre className={styles.sourceBlock}>
+            <code>{source}</code>
+          </pre>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/docusaurus/src/components/OmgBlock/styles.module.css
+++ b/docusaurus/src/components/OmgBlock/styles.module.css
@@ -1,0 +1,285 @@
+/* Container */
+.container {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  margin: 1.25rem 0;
+  overflow: hidden;
+  background: var(--ifm-background-surface-color);
+}
+
+/* Header */
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--ifm-color-emphasis-100);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.label {
+  font-weight: 600;
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.whenBadge {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 4px;
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-700);
+}
+
+/* Body */
+.body {
+  padding: 0;
+}
+
+/* Property table */
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+.table thead th {
+  text-align: left;
+  padding: 0.5rem 1rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ifm-color-emphasis-600);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  background: transparent;
+}
+
+.table tbody tr {
+  transition: background 0.1s;
+}
+
+.table tbody tr:hover {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.table tbody td {
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-100);
+  vertical-align: top;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Field cells */
+.fieldName code {
+  font-weight: 600;
+  font-size: 0.85rem;
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--ifm-color-emphasis-900);
+}
+
+.fieldType code {
+  font-size: 0.8rem;
+  background: var(--ifm-color-emphasis-200);
+  padding: 0.1rem 0.375rem;
+  border-radius: 3px;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.fieldRequired {
+  white-space: nowrap;
+}
+
+.requiredBadge {
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 0.1rem 0.375rem;
+  border-radius: 3px;
+  background: var(--ifm-color-emphasis-900);
+  color: var(--ifm-background-color);
+}
+
+.optionalBadge {
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 0.1rem 0.375rem;
+  border-radius: 3px;
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-600);
+}
+
+.fieldDescription {
+  font-size: 0.825rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+/* Annotations */
+.annotations {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-left: 0.375rem;
+}
+
+.annotation {
+  font-size: 0.7rem;
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-emphasis-600);
+  border: 1px solid var(--ifm-color-emphasis-200);
+}
+
+/* Returns list */
+.returnsList {
+  padding: 0.5rem 0;
+}
+
+.returnEntry {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-100);
+}
+
+.returnEntry:last-child {
+  border-bottom: none;
+}
+
+.statusCode {
+  display: inline-block;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  min-width: 3rem;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.statusSuccess {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.statusRedirect {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.statusClientError {
+  background: #ffedd5;
+  color: #9a3412;
+}
+
+.statusServerError {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+[data-theme='dark'] .statusSuccess {
+  background: #14532d;
+  color: #86efac;
+}
+
+[data-theme='dark'] .statusRedirect {
+  background: #78350f;
+  color: #fde68a;
+}
+
+[data-theme='dark'] .statusClientError {
+  background: #7c2d12;
+  color: #fdba74;
+}
+
+[data-theme='dark'] .statusServerError {
+  background: #7f1d1d;
+  color: #fca5a5;
+}
+
+.returnContent {
+  flex: 1;
+  min-width: 0;
+}
+
+.returnType {
+  font-size: 0.85rem;
+  background: var(--ifm-color-emphasis-200);
+  padding: 0.1rem 0.375rem;
+  border-radius: 3px;
+}
+
+.condition {
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-600);
+  font-family: var(--ifm-font-family-monospace);
+}
+
+.conditionKeyword {
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.returnDescription {
+  margin-top: 0.2rem;
+  font-size: 0.825rem;
+  color: var(--ifm-color-emphasis-700);
+  font-style: italic;
+}
+
+/* Source view */
+.sourceBlock {
+  margin: 0;
+  border-radius: 0;
+  border: none;
+  font-size: 0.85rem;
+  background: var(--ifm-color-emphasis-100);
+}
+
+.sourceBlock code {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+/* Collapsible source */
+.sourceDetails {
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.sourceSummary {
+  padding: 0.4rem 1rem;
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-600);
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+
+.sourceSummary::-webkit-details-marker {
+  display: none;
+}
+
+.sourceSummary:hover {
+  color: var(--ifm-color-emphasis-800);
+  background: var(--ifm-color-emphasis-100);
+}
+
+.sourceDetails pre {
+  margin: 0;
+  border-radius: 0;
+  font-size: 0.8rem;
+  background: var(--ifm-color-emphasis-100);
+}

--- a/docusaurus/src/theme/MDXComponents.tsx
+++ b/docusaurus/src/theme/MDXComponents.tsx
@@ -1,0 +1,7 @@
+import MDXComponents from '@theme-original/MDXComponents';
+import OmgBlock from '@site/src/components/OmgBlock';
+
+export default {
+  ...MDXComponents,
+  OmgBlock,
+};


### PR DESCRIPTION
## Summary
This PR introduces a new `OmgBlock` component and supporting infrastructure for rendering structured API documentation blocks in Docusaurus. The component parses and displays various API specification elements (parameters, headers, responses, etc.) with intelligent formatting and optional source code views.

## Key Changes

- **New OmgBlock Component** (`docusaurus/src/components/OmgBlock/index.tsx`):
  - React component that renders API documentation blocks with support for multiple block types (`omg.path`, `omg.query`, `omg.headers`, `omg.body`, `omg.response`, `omg.returns`, `omg.example`, `omg.type`, `omg.errors`, `omg.config`)
  - Includes lightweight parsers for field schemas and return types
  - Renders structured tables for field definitions with name, type, annotations, and descriptions
  - Displays HTTP status codes with color-coded badges (success/redirect/client error/server error)
  - Supports conditional rendering with `@when` annotations
  - Provides collapsible "View source" details for structured views

- **Styling** (`docusaurus/src/components/OmgBlock/styles.module.css`):
  - Comprehensive CSS module with responsive table layouts
  - Dark mode support for status code badges
  - Hover effects and visual hierarchy for better readability
  - Consistent use of Docusaurus design tokens

- **Remark Plugin** (`docusaurus/plugins/remark-omg.ts`):
  - Unified/remark plugin that transforms markdown code blocks with `omg.*` language tags into `OmgBlock` JSX components
  - Extracts metadata from language tags (e.g., `omg.response.201` → blockType + statusCode)
  - Parses `@when()` conditions from code block metadata
  - Generates proper MDX JSX flow elements with typed attributes

- **MDX Integration** (`docusaurus/src/theme/MDXComponents.tsx`):
  - Registers `OmgBlock` component in MDX component overrides for use in markdown documents

- **Docusaurus Config** (`docusaurus/docusaurus.config.ts`):
  - Integrates the remark plugin into the markdown processing pipeline

## Implementation Details

- The field parser handles complex nested structures (objects, arrays) and extracts inline comments, type annotations, and optional/required markers
- Status codes are color-coded using semantic colors (green for 2xx, amber for 3xx, orange for 4xx, red for 5xx)
- The component gracefully falls back to source code view when structured parsing isn't applicable
- All styling uses CSS custom properties for theme consistency and dark mode support

https://claude.ai/code/session_01HBqkx7kqwNvPPv7p2vDb1M