### PR TITLE
fix(importer): collapse multi-line descriptions and bracket-form enum/union arrays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,15 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
-      - name: Type check
-        run: npm run typecheck
-
+      # Build before typecheck: each workspace's package.json points `main`/`types`
+      # at `dist/`, so cross-workspace imports only resolve once every package
+      # has been compiled. `tsc --noEmit` against an unbuilt tree fails with
+      # TS2307 on every cross-package import.
       - name: Build
         run: npm run build
+
+      - name: Type check
+        run: npm run typecheck
 
       - name: Test
         run: npm test

--- a/packages/omg-importer/src/generator.test.ts
+++ b/packages/omg-importer/src/generator.test.ts
@@ -224,6 +224,30 @@ describe('generateSchema', () => {
 
       expect(result).toContain('// Unique identifier');
     });
+
+    it('collapses newlines in property descriptions onto a single line', () => {
+      const schema: OmgSchema = {
+        kind: 'object',
+        properties: {
+          state: {
+            kind: 'primitive',
+            type: 'string',
+            annotations: [],
+            description:
+              'The reason the instrument was blocked:\n  - USER: blocked by the account owner\n  - SYSTEM: blocked by the platform',
+          },
+        },
+        annotations: [],
+      };
+
+      const result = generateSchema(schema, opts, 0);
+
+      // No raw newline followed by a hyphen — that pattern breaks the parser
+      expect(result).not.toMatch(/\n\s*-\s/);
+      expect(result).toContain(
+        '// The reason the instrument was blocked: - USER: blocked by the account owner - SYSTEM: blocked by the platform'
+      );
+    });
   });
 
   describe('arrays', () => {
@@ -245,6 +269,39 @@ describe('generateSchema', () => {
       };
 
       expect(generateSchema(schema, opts, 0)).toBe('string[] @minItems(1)');
+    });
+
+    it('uses bracket form for arrays of enums to avoid precedence bug', () => {
+      const schema: OmgSchema = {
+        kind: 'array',
+        items: {
+          kind: 'enum',
+          values: ['USER', 'SYSTEM', 'LOST'],
+          annotations: [],
+        },
+        annotations: [],
+      };
+
+      // `"USER" | "SYSTEM" | "LOST"[]` parses as `"USER" | "SYSTEM" | Array<"LOST">`.
+      // Bracket form `["USER" | "SYSTEM" | "LOST"]` is unambiguous.
+      expect(generateSchema(schema, opts, 0)).toBe('["USER" | "SYSTEM" | "LOST"]');
+    });
+
+    it('uses bracket form for arrays of unions to avoid precedence bug', () => {
+      const schema: OmgSchema = {
+        kind: 'array',
+        items: {
+          kind: 'union',
+          types: [
+            { kind: 'primitive', type: 'string', annotations: [] },
+            { kind: 'primitive', type: 'integer', annotations: [] },
+          ],
+          annotations: [],
+        },
+        annotations: [],
+      };
+
+      expect(generateSchema(schema, opts, 0)).toBe('[string | integer]');
     });
   });
 

--- a/packages/omg-importer/src/generator.ts
+++ b/packages/omg-importer/src/generator.ts
@@ -217,6 +217,16 @@ function quoteName(name: string): string {
 }
 
 /**
+ * Inline-object property descriptions must stay on a single line — newlines
+ * break the parser's brace tracking when subsequent lines start with characters
+ * like `-` (very common for hyphen-bulleted enum value docs).
+ */
+function sanitiseInlineDescription(desc: string | undefined): string {
+  if (!desc) return '';
+  return desc.replace(/\s+/g, ' ').trim();
+}
+
+/**
  * Generate object type
  */
 function generateObject(type: OmgObject, opts: GeneratorOptions, depth: number): string {
@@ -236,7 +246,8 @@ function generateObject(type: OmgObject, opts: GeneratorOptions, depth: number):
     const quotedName = quoteName(name);
     const optional = propType.optional ? '?' : '';
     const value = generateSchema(propType, opts, depth + 1);
-    const comment = propType.description ? `  // ${propType.description}` : '';
+    const sanitised = sanitiseInlineDescription(propType.description);
+    const comment = sanitised ? `  // ${sanitised}` : '';
 
     // For simple types, put on one line
     if (isSimpleType(propType)) {
@@ -264,8 +275,16 @@ function generateObject(type: OmgObject, opts: GeneratorOptions, depth: number):
 function generateArray(type: OmgArray, opts: GeneratorOptions, depth: number): string {
   const itemsStr = generateSchema(type.items, opts, depth);
 
-  // For simple item types, use suffix notation
-  if (isSimpleType(type.items) && !itemsStr.includes('\n')) {
+  // Suffix form `T[]` is only safe when items are atomic. Unions and enums
+  // bind tighter than `[]` in the grammar (`"A" | "B"[]` parses as
+  // `"A" | Array<"B">`), so they must use the bracket form `[T]` instead.
+  const itemsAreAtomic =
+    isSimpleType(type.items) &&
+    !itemsStr.includes('\n') &&
+    type.items.kind !== 'union' &&
+    type.items.kind !== 'enum';
+
+  if (itemsAreAtomic) {
     let result = `${itemsStr}[]`;
     result += generateAnnotations(type.annotations);
     if (type.nullable) {


### PR DESCRIPTION
## Summary

- Collapse newlines in inline-object property descriptions to a single line — fixes #48
- Use bracket form `["A" | "B"]` instead of suffix form `"A" | "B"[]` when array items are a union or enum — fixes #49

## Why

Both bugs surfaced while round-tripping a real-world OpenAPI spec (Weavr's Multi API, 135 ops / 217 types, generating 365 `.omg.md` files) through `omg import` → `omg build`.

- **Description bleed** (#48): OpenAPI descriptions for enum fields are commonly hyphen-bulleted markdown like ``"The reason blocked:\n  - USER: blocked by owner\n  - SYSTEM: ...`". When emitted as ``// comment``, the continuation lines start with `-` and break the parser's brace tracking on the next property. Dominant breakage — affected 172/365 generated files.
- **Enum array precedence** (#49): for a string array with an enum on items, the importer emitted ``state: "USER" | "SYSTEM" | "LOST"[]``. Operator precedence makes that ``"USER" | "SYSTEM" | Array<"LOST">``, not ``Array<"USER" | "SYSTEM" | "LOST">``. Silent semantic bug.

## Approach

- New helper `sanitiseInlineDescription()` in `generator.ts` collapses any whitespace (including newlines and indent) in property descriptions to single spaces before emitting `// ...`.
- `generateArray()` now treats enum and union items as non-atomic — these always emit `[T]` bracket form, which the parser accepts unambiguously as array-of-T.

## Impact on Weavr's Multi API round-trip

Round-trip parse failures: **172/365 → 40/365** (78% reduction; 95 of 135 endpoints now compile).

## Test plan

- [x] `npm test -w omg-importer` — 69/69 pass, including 3 new tests (single-line description collapse, enum-array bracket form, union-array bracket form)
- [x] `npm run build -w omg-importer && npm run build -w omg-md-cli` — clean
- [x] `omg import` → `omg build` round-trip on Weavr's Multi API improved 172→40 failures (other patterns remain — separate follow-ups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)