### PR TITLE
fix(importer): escape string args and use bracket form for annotated array items

### DIFF
--- a/packages/omg-importer/src/generator.test.ts
+++ b/packages/omg-importer/src/generator.test.ts
@@ -303,6 +303,46 @@ describe('generateSchema', () => {
 
       expect(generateSchema(schema, opts, 0)).toBe('[string | integer]');
     });
+
+    it('uses bracket form when item type has annotations', () => {
+      // `string @pattern("…")[]` doesn't parse: annotations close out the type
+      // expression, leaving `[]` in property-name position.
+      const schema: OmgSchema = {
+        kind: 'array',
+        items: {
+          kind: 'primitive',
+          type: 'string',
+          annotations: [{ name: 'pattern', args: ['^[A-Z]{2}$'] }],
+        },
+        annotations: [],
+      };
+
+      expect(generateSchema(schema, opts, 0)).toBe('[string @pattern("^[A-Z]{2}$")]');
+    });
+  });
+
+  describe('annotation string args', () => {
+    it('escapes embedded double quotes in pattern annotations', () => {
+      const schema: OmgSchema = {
+        kind: 'primitive',
+        type: 'string',
+        annotations: [{ name: 'pattern', args: ['^[a-zA-Z\\s"]*$'] }],
+      };
+
+      // Importantly, the embedded `"` is escaped so the lexer doesn't terminate
+      // the string early.
+      expect(generateSchema(schema, opts, 0)).toBe('string @pattern("^[a-zA-Z\\\\s\\"]*$")');
+    });
+
+    it('escapes embedded backslashes', () => {
+      const schema: OmgSchema = {
+        kind: 'primitive',
+        type: 'string',
+        annotations: [{ name: 'pattern', args: ['a\\.b'] }],
+      };
+
+      expect(generateSchema(schema, opts, 0)).toBe('string @pattern("a\\\\.b")');
+    });
   });
 
   describe('enums', () => {

--- a/packages/omg-importer/src/generator.ts
+++ b/packages/omg-importer/src/generator.ts
@@ -275,14 +275,21 @@ function generateObject(type: OmgObject, opts: GeneratorOptions, depth: number):
 function generateArray(type: OmgArray, opts: GeneratorOptions, depth: number): string {
   const itemsStr = generateSchema(type.items, opts, depth);
 
-  // Suffix form `T[]` is only safe when items are atomic. Unions and enums
-  // bind tighter than `[]` in the grammar (`"A" | "B"[]` parses as
-  // `"A" | Array<"B">`), so they must use the bracket form `[T]` instead.
+  // Suffix form `T[]` is only safe when items are atomic. Items with annotations
+  // are not atomic — the grammar parses `string @pattern("…")` as a complete type
+  // expression, then chokes on the trailing `[]`. Unions and enums bind tighter
+  // than `[]` so they have the same problem (`"A" | "B"[]` parses as
+  // `"A" | Array<"B">`). All three cases must use the bracket form `[T]`.
+  const itemsHaveAnnotations =
+    'annotations' in type.items &&
+    Array.isArray(type.items.annotations) &&
+    type.items.annotations.length > 0;
   const itemsAreAtomic =
     isSimpleType(type.items) &&
     !itemsStr.includes('\n') &&
     type.items.kind !== 'union' &&
-    type.items.kind !== 'enum';
+    type.items.kind !== 'enum' &&
+    !itemsHaveAnnotations;
 
   if (itemsAreAtomic) {
     let result = `${itemsStr}[]`;
@@ -384,6 +391,15 @@ function generateReference(type: OmgReference): string {
 }
 
 /**
+ * String args (most importantly regex patterns) routinely contain `"` and `\`
+ * — both must be escaped or the lexer terminates the string early and crashes
+ * on whatever follows.
+ */
+function escapeStringArg(arg: string): string {
+  return '"' + arg.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+}
+
+/**
  * Generate annotations string
  */
 function generateAnnotations(annotations: OmgAnnotation[]): string {
@@ -398,11 +414,7 @@ function generateAnnotations(annotations: OmgAnnotation[]): string {
 
     const args = ann.args.map((arg) => {
       if (typeof arg === 'string') {
-        // Check if it's a regex pattern
-        if (ann.name === 'pattern') {
-          return `"${arg}"`;
-        }
-        return `"${arg}"`;
+        return escapeStringArg(arg);
       }
       return String(arg);
     });


### PR DESCRIPTION
## Summary

Two remaining round-trip blockers on real-world OpenAPI specs.

1. **String args in annotations were emitted unescaped.** Regex patterns containing `"` (e.g. \`@pattern("^[a-zA-Z\"]*$")\`) closed the string lexer early and crashed on the next character with \`Unexpected character '%' at line N, column N\`. Now escape \`"\` and \`\\\` per the OMG string literal grammar.
2. **Array items with annotations emitted suffix form** \`string @pattern("…")[]\`, which doesn't parse — annotations close out the type expression, leaving \`[]\` in property-name position on the next line. Treat annotated items the same way as union/enum items: emit bracket form \`[string @pattern("…")]\`.

## Impact on Weavr's Multi API round-trip

This is the final piece of the round-trip story:

| stage | failures |
| --- | --- |
| Before #50 | 172 / 365 |
| After #50 (descriptions + enum/union arrays) | 40 / 365 |
| **After this PR (escapes + annotated arrays)** | **0 / 364** |

\`omg build\` against the imported tree now produces a valid OpenAPI 3.1 spec end-to-end: 134 endpoints across 108 paths, 1.2 MB YAML.

## Test plan

- [x] \`npm test -w omg-importer\` — 72/72 pass (3 new tests: escapes embedded \`"\`, escapes \`\\\`, bracket form for annotated items)
- [x] \`npm run build\` — clean
- [x] End-to-end on Weavr's Multi API: import → parse + resolve all 364 generated files → \`omg build\` → valid OpenAPI 3.1
- [ ] CI on Node 18/20 still blocked by the \`require()\` of ESM \`unified\` issue tracked in #51 — orthogonal

🤖 Generated with [Claude Code](https://claude.com/claude-code)