### PR TITLE
fix(parser): support inline-object arrays and parenthesised types

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,29 @@ jobs:
       - name: Test
         run: npm test
 
+      # Order matters: dependents must publish after dependencies so the
+      # version they pin actually exists on npm when consumers install.
+      # omg-parser is a leaf; everything else depends on it (directly or
+      # transitively). omg-md-cli depends on all the others.
+
       - name: Publish omg-parser
         run: npm publish --workspace=omg-parser --provenance --access public
         continue-on-error: true
 
       - name: Publish omg-compiler
         run: npm publish --workspace=omg-compiler --provenance --access public
+        continue-on-error: true
+
+      - name: Publish omg-linter
+        run: npm publish --workspace=omg-linter --provenance --access public
+        continue-on-error: true
+
+      - name: Publish omg-importer
+        run: npm publish --workspace=omg-importer --provenance --access public
+        continue-on-error: true
+
+      - name: Publish omg-mock-server
+        run: npm publish --workspace=omg-mock-server --provenance --access public
         continue-on-error: true
 
       - name: Publish omg-lsp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Schema parser supports inline-object array syntax: `{ id: string }[]` (#45)
+- Schema parser supports parenthesised type expressions: `(A | B)[]`, `(A & B)[]`, and parens for disambiguation (#46)
+
 ## [1.2.0] - 2024-12-21
 
 ### Added

--- a/packages/omg-parser/src/schema-parser.test.ts
+++ b/packages/omg-parser/src/schema-parser.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { parseSchema } from './schema-parser.js';
-import type { OmgIntersection, OmgUnion, OmgReference, OmgPrimitive, OmgObject } from './types.js';
+import type {
+  OmgIntersection,
+  OmgUnion,
+  OmgReference,
+  OmgPrimitive,
+  OmgObject,
+  OmgArray,
+  OmgEnum,
+} from './types.js';
 
 describe('parseSchema - intersection types', () => {
   describe('basic intersection parsing', () => {
@@ -222,5 +230,99 @@ describe('parseSchema - existing functionality preserved', () => {
     expect(result.kind).toBe('object');
     const obj = result as OmgObject;
     expect(obj.properties.name.optional).toBe(true);
+  });
+});
+
+describe('parseSchema - inline-object arrays (#45)', () => {
+  it('should parse `{ id: string }[]` as array of object', () => {
+    const result = parseSchema('{ id: string, name: string }[]');
+
+    expect(result.kind).toBe('array');
+    const arr = result as OmgArray;
+    expect(arr.items.kind).toBe('object');
+    const obj = arr.items as OmgObject;
+    expect(obj.properties).toHaveProperty('id');
+    expect(obj.properties).toHaveProperty('name');
+  });
+
+  it('should parse inline-object array as property value', () => {
+    const result = parseSchema('{ items: { id: string, name: string }[] }');
+
+    expect(result.kind).toBe('object');
+    const outer = result as OmgObject;
+    expect(outer.properties.items.kind).toBe('array');
+
+    const itemsArray = outer.properties.items as OmgArray;
+    expect(itemsArray.items.kind).toBe('object');
+    expect((itemsArray.items as OmgObject).properties).toHaveProperty('id');
+  });
+
+  it('should parse envelope response shape with inline-object array', () => {
+    const result = parseSchema('{ items: { id: string }[], count: integer }');
+
+    expect(result.kind).toBe('object');
+    const outer = result as OmgObject;
+    expect(outer.properties.items.kind).toBe('array');
+    expect(outer.properties.count.kind).toBe('primitive');
+    expect((outer.properties.count as OmgPrimitive).type).toBe('integer');
+  });
+
+  it('should parse `{...}[]?` as optional array of object', () => {
+    const result = parseSchema('{ x: { id: string }[]? }');
+
+    const obj = result as OmgObject;
+    expect(obj.properties.x.kind).toBe('array');
+    expect(obj.properties.x.optional).toBe(true);
+  });
+});
+
+describe('parseSchema - parenthesised type expressions (#46)', () => {
+  it('should parse `(A | B)[]` as array of union', () => {
+    const result = parseSchema('("ACTIVE" | "BLOCKED" | "DESTROYED")[]');
+
+    expect(result.kind).toBe('array');
+    const arr = result as OmgArray;
+    expect(arr.items.kind).toBe('enum');
+    const enumType = arr.items as OmgEnum;
+    expect(enumType.values).toEqual(['ACTIVE', 'BLOCKED', 'DESTROYED']);
+  });
+
+  it('should parse parenthesised enum array as property value', () => {
+    const result = parseSchema('{ state?: ("ACTIVE" | "BLOCKED")[] }');
+
+    expect(result.kind).toBe('object');
+    const obj = result as OmgObject;
+    expect(obj.properties.state.kind).toBe('array');
+    expect(obj.properties.state.optional).toBe(true);
+
+    const arr = obj.properties.state as OmgArray;
+    expect(arr.items.kind).toBe('enum');
+    expect((arr.items as OmgEnum).values).toEqual(['ACTIVE', 'BLOCKED']);
+  });
+
+  it('should parse `(A & B)[]` as array of intersection', () => {
+    const result = parseSchema('(TypeA & TypeB)[]');
+
+    expect(result.kind).toBe('array');
+    const arr = result as OmgArray;
+    expect(arr.items.kind).toBe('intersection');
+    const intersection = arr.items as OmgIntersection;
+    expect(intersection.types).toHaveLength(2);
+  });
+
+  it('should parse parens for disambiguation: `(A | B) & C`', () => {
+    const result = parseSchema('(TypeA | TypeB) & TypeC');
+
+    expect(result.kind).toBe('intersection');
+    const intersection = result as OmgIntersection;
+    expect(intersection.types).toHaveLength(2);
+    expect(intersection.types[0].kind).toBe('union');
+    expect((intersection.types[1] as OmgReference).name).toBe('TypeC');
+  });
+
+  it('should parse simple parenthesised primitive', () => {
+    const result = parseSchema('(string)');
+    expect(result.kind).toBe('primitive');
+    expect((result as OmgPrimitive).type).toBe('string');
   });
 });

--- a/packages/omg-parser/src/schema-parser.ts
+++ b/packages/omg-parser/src/schema-parser.ts
@@ -368,6 +368,35 @@ class Parser {
     return annotations;
   }
 
+  /**
+   * Wrap a type in array(s) for each trailing `[]` suffix, then apply
+   * optional marker and annotations. Supports multi-dimensional arrays
+   * like `string[][]`.
+   */
+  private applyArrayAndModifiers(type: OmgType): OmgType {
+    while (this.check('LBRACKET')) {
+      this.advance();
+      this.expect('RBRACKET');
+      type = {
+        kind: 'array',
+        items: type,
+        annotations: [],
+      };
+    }
+
+    if (this.check('QUESTION')) {
+      this.advance();
+      (type as any).optional = true;
+    }
+
+    const annotations = this.parseAnnotations();
+    if (annotations.length > 0) {
+      type.annotations = [...(type.annotations || []), ...annotations];
+    }
+
+    return type;
+  }
+
   private parsePrimaryType(): OmgType {
     const token = this.currentToken;
 
@@ -570,9 +599,18 @@ class Parser {
       };
     }
 
-    // Object
+    // Object — supports `{...}`, `{...}[]`, `{...}?`, `{...} @annotation`.
     if (this.check('LBRACE')) {
-      return this.parseObject();
+      return this.applyArrayAndModifiers(this.parseObject());
+    }
+
+    // Parenthesised type expression: `( Type )` — supports `(A | B)[]`, `(A & B)[]`,
+    // and disambiguation in general.
+    if (this.check('LPAREN')) {
+      this.advance();
+      const inner = this.parseType();
+      this.expect('RPAREN');
+      return this.applyArrayAndModifiers(inner);
     }
 
     const suggestions = this.getSuggestions(token);
@@ -734,18 +772,10 @@ class Parser {
 
     this.expect('RBRACE');
 
-    const optional = this.check('QUESTION');
-    if (optional) {
-      this.advance();
-    }
-
-    const annotations = this.parseAnnotations();
-
     return {
       kind: 'object',
       properties,
-      optional,
-      annotations,
+      annotations: [],
     };
   }
 


### PR DESCRIPTION
## Summary

- Schema parser now accepts `{ ... }[]` for inline-object arrays — common for envelope responses like `{ items: { id: string }[], count: integer }` (#45)
- Adds parenthesised type expressions `( ... )` for grouping — enables `("A" | "B")[]`, `(A & B)[]`, and disambiguation (#46)
- Postfix array suffix unified via `applyArrayAndModifiers`, which supports multi-dim forms and combines cleanly with `?` / `@annotation`
- Bundled: `release.yml` now publishes all 7 workspace packages, not just 4 — `omg-md-cli@0.2.2` currently can't install because the `omg-importer@^0.2.2`, `omg-linter@^0.2.2`, `omg-mock-server@^0.2.2` it pins were never published. Adds publish steps for those three, reordered leaves-first.

Fixes #45
Fixes #46

## Test plan

- [x] New `parseSchema` unit tests cover inline-object arrays, parenthesised enum arrays, intersection arrays, parens-for-precedence, and nested cases
- [x] All 128 parser tests pass; full workspace test suite passes (`npm test`)
- [x] End-to-end compile of `{ items: { id: string }[], count: integer }` + `("ACTIVE" | "BLOCKED" | "DESTROYED")[]` produces correct OpenAPI 3.1

## Action after merge (for the release.yml change)

Re-run `release.yml` against the existing v0.2.2 GitHub Release. Already-published packages will skip on version-conflict (`continue-on-error: true`); the three missing ones will publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)