### PR TITLE
fix: convert omg-parser, omg-compiler, omg-mock-server to ESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Schema parser supports inline-object array syntax: `{ id: string }[]` (#45)
 - Schema parser supports parenthesised type expressions: `(A | B)[]`, `(A & B)[]`, and parens for disambiguation (#46)
 
+### Fixed
+
+- `omg-parser`, `omg-compiler`, and `omg-mock-server` are now ESM packages, fixing `ERR_REQUIRE_ESM` when consumed on Node 18/20. The CLI and tests previously only worked on Node 22.12+ where `require(ESM)` is enabled by default. (#51)
+
 ## [1.2.0] - 2024-12-21
 
 ### Added

--- a/packages/omg-compiler/package.json
+++ b/packages/omg-compiler/package.json
@@ -22,6 +22,7 @@
     "specification",
     "codegen"
   ],
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/omg-mock-server/package.json
+++ b/packages/omg-mock-server/package.json
@@ -22,6 +22,7 @@
     "testing",
     "development"
   ],
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/omg-parser/package.json
+++ b/packages/omg-parser/package.json
@@ -21,6 +21,7 @@
     "api",
     "specification"
   ],
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary

Three of the seven workspace packages shipped as CommonJS even though their TypeScript sources use ESM `import` syntax with `.js` suffixes. That meant `tsc` emitted `require('unified')` — and since `unified@11` is ESM-only, the CLI crashed with `ERR_REQUIRE_ESM` on Node 18 and 20. It only worked on Node 22.12+ where `require(ESM)` is enabled by default.

Adding `"type": "module"` to the three CJS holdouts (`omg-parser`, `omg-compiler`, `omg-mock-server`) aligns their emitted output with what their source already declares. `omg-importer`, `omg-linter`, `omg-lsp`, and `omg-md-cli` were already ESM.

Fixes #51

## Test plan

- [x] Full test suite passes on Node 18 (119 parser tests + 20 CLI tests + 16 mock-server tests + 72 importer + 21 linter + 6 compiler)
- [x] Full test suite passes on Node 20 (same)
- [x] Full test suite passes on Node 24 (same)
- [x] `omg build` end-to-end works on Node 18, 20, 24 (no more `ERR_REQUIRE_ESM`)
- [x] `typecheck` / `format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)