### PR TITLE
fix(parser): merge multi-block params and emit bodyless responses for empty blocks

### DIFF
--- a/packages/omg-parser/src/resolver.test.ts
+++ b/packages/omg-parser/src/resolver.test.ts
@@ -1143,3 +1143,112 @@ path: /users
     expect(getDocumentCacheSize()).toBe(0);
   });
 });
+
+describe('buildEndpoints — multi-block partial merge', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+  });
+
+  it('merges properties from multiple omg.query blocks into a single parameter set', () => {
+    const content = `---
+method: GET
+path: /things
+operationId: thingsList
+---
+
+# List things
+
+\`\`\`omg.query
+{ search?: string }
+\`\`\`
+
+\`\`\`omg.query
+{ offset?: integer @min(0) }
+\`\`\`
+
+\`\`\`omg.query
+{ limit?: integer @min(1) @max(100) }
+\`\`\`
+`;
+
+    const doc = parseDocument(content, 'test.omg.md');
+    const resolved = resolveDocument(doc, { basePath: '/tmp' });
+    const endpoints = buildEndpoints(resolved);
+
+    expect(endpoints).toHaveLength(1);
+    const query = endpoints[0].parameters.query as { properties: Record<string, unknown> };
+    expect(query).toBeTruthy();
+    expect(Object.keys(query.properties).sort()).toEqual(['limit', 'offset', 'search']);
+  });
+
+  it('merges properties from multiple omg.headers blocks too', () => {
+    const content = `---
+method: POST
+path: /things
+operationId: thingsCreate
+---
+
+# Create thing
+
+\`\`\`omg.headers
+{ "X-Trace-Id"?: string }
+\`\`\`
+
+\`\`\`omg.headers
+{ "Idempotency-Key"?: string }
+\`\`\`
+`;
+
+    const doc = parseDocument(content, 'test.omg.md');
+    const resolved = resolveDocument(doc, { basePath: '/tmp' });
+    const endpoints = buildEndpoints(resolved);
+
+    const headers = endpoints[0].parameters.headers as { properties: Record<string, unknown> };
+    expect(headers).toBeTruthy();
+    expect(Object.keys(headers.properties).sort()).toEqual(['Idempotency-Key', 'X-Trace-Id']);
+  });
+});
+
+describe('buildEndpoints — empty response blocks', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+  });
+
+  it('emits bodyless responses for empty omg.response.<code> blocks', () => {
+    const content = `---
+method: GET
+path: /things
+operationId: thingsList
+---
+
+# List things
+
+\`\`\`omg.response.200
+{ items: string[] }
+\`\`\`
+
+\`\`\`omg.response.401
+
+\`\`\`
+
+\`\`\`omg.response.500
+
+\`\`\`
+`;
+
+    const doc = parseDocument(content, 'test.omg.md');
+    const resolved = resolveDocument(doc, { basePath: '/tmp' });
+    const endpoints = buildEndpoints(resolved);
+
+    const responses = endpoints[0].responses;
+    // The bodyless responses must be present — previously they were dropped
+    // because the parser left `block.parsed` undefined and buildEndpoint
+    // guarded on it.
+    expect(Object.keys(responses).sort()).toEqual(['200', '401', '500']);
+    expect(responses[200].schema).toBeTruthy();
+    expect(responses[401].schema).toBeNull();
+    expect(responses[500].schema).toBeNull();
+  });
+});

--- a/packages/omg-parser/src/resolver.ts
+++ b/packages/omg-parser/src/resolver.ts
@@ -13,6 +13,7 @@ import { parseReturnsBlock } from './returns-parser.js';
 import type {
   OmgDocument,
   OmgBlock,
+  OmgObject,
   ParsedEndpoint,
   ParsedApi,
   ParsedResponse,
@@ -22,6 +23,31 @@ import type {
   ApiFrontMatter,
   ParseWarning,
 } from './types.js';
+
+/**
+ * Merge multiple parameter blocks (omg.query, omg.headers) into a single
+ * object schema. Critical for partial support — the importer extracts shared
+ * params into partials/ and emits one `{{> query/<name> }}` reference per
+ * param, so a typical endpoint has 5+ omg.query blocks after partial
+ * resolution. `find()` would drop all but the first; this merges their
+ * properties.
+ */
+function mergeObjectBlocks(blocks: OmgBlock[]): OmgObject | null {
+  const objects = blocks
+    .map((b) => b.parsed)
+    .filter((p): p is OmgObject => !!p && p.kind === 'object');
+  if (objects.length === 0) return null;
+  if (objects.length === 1) return objects[0];
+  const merged: OmgObject = {
+    kind: 'object',
+    properties: {},
+    annotations: [],
+  };
+  for (const obj of objects) {
+    Object.assign(merged.properties, obj.properties);
+  }
+  return merged;
+}
 
 /**
  * Document cache entry with content hash for invalidation
@@ -458,8 +484,8 @@ function buildExpandedEndpoints(
 
     // Collect blocks by type (from filtered variant blocks)
     const pathBlock = variantBlocks.find((b) => b.type === 'omg.path');
-    const queryBlock = variantBlocks.find((b) => b.type === 'omg.query');
-    const headersBlock = variantBlocks.find((b) => b.type === 'omg.headers');
+    const queryBlocks = variantBlocks.filter((b) => b.type === 'omg.query');
+    const headersBlocks = variantBlocks.filter((b) => b.type === 'omg.headers');
     const bodyBlock = variantBlocks.find((b) => b.type === 'omg.body');
     const returnsBlocks = variantBlocks.filter((b) => b.type === 'omg.returns');
     const responseBlocks = variantBlocks.filter(
@@ -483,12 +509,14 @@ function buildExpandedEndpoints(
 
     for (const block of responseBlocks) {
       const statusCode = block.statusCode || 200;
-      if (block.parsed) {
-        if (!responses[statusCode]) {
-          responses[statusCode] = {
-            schema: block.parsed,
-          };
-        }
+      // Empty response blocks (e.g. `omg.response.401` with no body) declare
+      // a bodyless response — emit them with schema=null rather than drop
+      // silently. The compiler will source the description from the standard
+      // HTTP status text.
+      if (!responses[statusCode]) {
+        responses[statusCode] = {
+          schema: block.parsed ?? null,
+        };
       }
     }
 
@@ -504,8 +532,8 @@ function buildExpandedEndpoints(
       webhooks: frontMatter?.webhooks || {},
       parameters: {
         path: pathBlock?.parsed || null,
-        query: queryBlock?.parsed || null,
-        headers: headersBlock?.parsed || null,
+        query: mergeObjectBlocks(queryBlocks),
+        headers: mergeObjectBlocks(headersBlocks),
       },
       requestBody: bodyBlock?.parsed || null,
       responses,
@@ -534,8 +562,8 @@ function buildSingleEndpoint(
 
   // Collect blocks by type
   const pathBlock = doc.resolvedBlocks.find((b) => b.type === 'omg.path');
-  const queryBlock = doc.resolvedBlocks.find((b) => b.type === 'omg.query');
-  const headersBlock = doc.resolvedBlocks.find((b) => b.type === 'omg.headers');
+  const queryBlocks = doc.resolvedBlocks.filter((b) => b.type === 'omg.query');
+  const headersBlocks = doc.resolvedBlocks.filter((b) => b.type === 'omg.headers');
   const bodyBlock = doc.resolvedBlocks.find((b) => b.type === 'omg.body');
   const returnsBlocks = doc.resolvedBlocks.filter((b) => b.type === 'omg.returns');
   const responseBlocks = doc.resolvedBlocks.filter(
@@ -559,16 +587,16 @@ function buildSingleEndpoint(
     }
   }
 
-  // Then, process legacy omg.response.XXX blocks (without conditions)
+  // Then, process legacy omg.response.XXX blocks (without conditions).
+  // Empty blocks (e.g. `omg.response.401` with no body) declare a bodyless
+  // response and must be emitted with schema=null rather than dropped — the
+  // compiler sources the description from the standard HTTP status text.
   for (const block of responseBlocks) {
     const statusCode = block.statusCode || 200;
-    if (block.parsed) {
-      // Only add if not already defined by omg.returns block
-      if (!responses[statusCode]) {
-        responses[statusCode] = {
-          schema: block.parsed,
-        };
-      }
+    if (!responses[statusCode]) {
+      responses[statusCode] = {
+        schema: block.parsed ?? null,
+      };
     }
   }
 
@@ -637,8 +665,8 @@ function buildSingleEndpoint(
     webhooks: frontMatter?.webhooks || {},
     parameters: {
       path: pathBlock?.parsed || null,
-      query: queryBlock?.parsed || null,
-      headers: headersBlock?.parsed || null,
+      query: mergeObjectBlocks(queryBlocks),
+      headers: mergeObjectBlocks(headersBlocks),
     },
     requestBody: bodyBlock?.parsed || null,
     responses,


### PR DESCRIPTION
## Summary

Two sources of silent data loss in `packages/omg-parser/src/resolver.ts` when round-tripping real OpenAPI specs through `omg import` + `omg build`.

### 1. Multi-block params dropped (fixes #76)

`buildEndpoint` used `Array.find()` to pick **one** `omg.query` (and `omg.headers`) block, dropping every block after the first. This breaks partial support — the importer extracts shared params into `partials/query/<name>.omg.md` and emits one `{{> query/<name> }}` reference per param, so a typical endpoint has 5+ `omg.query` blocks after partial resolution. All but the first were silently ignored.

Fix: collect with `filter()` and merge each block's `properties` into one.

### 2. Empty response blocks dropped (fixes #77)

Empty `omg.response.<code>` blocks — e.g. `omg.response.401` with no body, common for shared error responses — had `block.parsed === undefined`. `buildEndpoint` guarded responses on `if (block.parsed)`, so the bodyless declaration was dropped entirely.

Fix: emit them with `schema: null`. The compiler already handles null schema correctly (emits a description-only response) and already has the HTTP status-code → description map.

Both fixes applied to `buildSingleEndpoint` and `buildExpandedEndpoints` (the variant-expansion path had identical bugs).

## Impact on a sample project's round-trip

|   | before | after |
| --- | --- | --- |
| ops with missing query params | 16 | **0** |
| total query params missing | ~89 | **0** |
| ops with missing responses | 133 | 124 |
| total response codes missing | ~702 | 124 |

The remaining 124 missing responses are all OpenAPI's `default` catch-all — the importer doesn't currently emit those. Separate follow-up; not a parser bug.

## Tests

3 new resolver tests:
- Multi-block `omg.query` merge (3 blocks → 1 merged with all 3 properties)
- Multi-block `omg.headers` merge
- Empty `omg.response.401` / `omg.response.500` → bodyless responses

All 131 parser tests pass; compiler (6) and md-cli (20) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)