### PR TITLE
feat: support OpenAPI `default` response across parser/compiler/importer

### DIFF
--- a/packages/omg-compiler/src/openapi.ts
+++ b/packages/omg-compiler/src/openapi.ts
@@ -479,7 +479,9 @@ function compileEndpointWithContext(
     ParsedResponse,
   ][]) {
     const ctx = { ...parentCtx, path: [baseName, `Response${statusCode}`], depth: 0 };
-    const description = response.description || getStatusDescription(parseInt(statusCode));
+    const description =
+      response.description ||
+      (statusCode === 'default' ? 'Default response' : getStatusDescription(parseInt(statusCode)));
 
     const oasResponse: ResponseObject = { description };
 

--- a/packages/omg-importer/src/importer.ts
+++ b/packages/omg-importer/src/importer.ts
@@ -491,19 +491,28 @@ function convertOperation(
   if (operation.responses) {
     for (const [statusCode, response] of Object.entries(operation.responses)) {
       const parsedResponse = convertResponseFull(response, spec, ctx, warnings);
-      const code = parseInt(statusCode, 10);
 
-      if (!isNaN(code)) {
-        const blockType: OmgBlockType = code === 200 ? 'omg.response' : 'omg.response';
-        blocks.push({
-          type: blockType,
-          statusCode: code === 200 ? undefined : code,
-          content: '',
-          parsed: parsedResponse.schema || undefined,
-          parsedResponse, // Store full response metadata
-          line: 0,
-        });
+      // Resolve the OMG statusCode field: numeric codes parse as numbers,
+      // 'default' (OpenAPI's catch-all) is passed through as a string literal,
+      // anything else is unknown and skipped.
+      let omgStatusCode: number | 'default' | undefined;
+      if (statusCode === 'default') {
+        omgStatusCode = 'default';
+      } else {
+        const code = parseInt(statusCode, 10);
+        if (isNaN(code)) continue;
+        // 200 is the implicit default for `omg.response` with no suffix.
+        omgStatusCode = code === 200 ? undefined : code;
       }
+
+      blocks.push({
+        type: 'omg.response',
+        statusCode: omgStatusCode,
+        content: '',
+        parsed: parsedResponse.schema || undefined,
+        parsedResponse, // Store full response metadata
+        line: 0,
+      });
     }
   }
 

--- a/packages/omg-parser/src/document-parser.ts
+++ b/packages/omg-parser/src/document-parser.ts
@@ -24,9 +24,9 @@ import type {
 } from './types.js';
 
 // Block type patterns
-// Matches: omg.body, omg.response.201
+// Matches: omg.body, omg.response.201, omg.response.default
 const OMG_BLOCK_PATTERN =
-  /^omg\.(path|query|headers|body|response|returns|example|type|errors|config)(\.(\d+))?$/;
+  /^omg\.(path|query|headers|body|response|returns|example|type|errors|config)(\.(\d+|default))?$/;
 // Extended pattern for example blocks with optional name
 // Matches: omg.example, omg.example.201, omg.example.success, omg.example.201.success
 const EXAMPLE_BLOCK_PATTERN = /^omg\.example(?:\.(\d+))?(?:\.([a-zA-Z][a-zA-Z0-9_-]*))?$/;
@@ -196,7 +196,9 @@ function extractCodeBlocks(tree: Root, rawContent: string): OmgBlock[] {
     const match = lang.match(OMG_BLOCK_PATTERN);
     if (match) {
       const blockType = `omg.${match[1]}` as OmgBlockType;
-      const statusCode = match[3] ? parseInt(match[3], 10) : undefined;
+      const codeRaw = match[3];
+      const statusCode: number | 'default' | undefined =
+        codeRaw === 'default' ? 'default' : codeRaw ? parseInt(codeRaw, 10) : undefined;
 
       // Parse @when condition from meta if present
       // remark-parse puts everything after the language tag in node.meta

--- a/packages/omg-parser/src/resolver.test.ts
+++ b/packages/omg-parser/src/resolver.test.ts
@@ -1210,6 +1210,40 @@ operationId: thingsCreate
   });
 });
 
+describe('buildEndpoints — `default` response key', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+  });
+
+  it('parses omg.response.default and stores it under the string key "default"', () => {
+    const content = `---
+method: GET
+path: /things
+operationId: thingsList
+---
+
+# List things
+
+\`\`\`omg.response.200
+{ items: string[] }
+\`\`\`
+
+\`\`\`omg.response.default
+{ errorCode: string, message: string }
+\`\`\`
+`;
+
+    const doc = parseDocument(content, 'test.omg.md');
+    const resolved = resolveDocument(doc, { basePath: '/tmp' });
+    const endpoints = buildEndpoints(resolved);
+
+    const responses = endpoints[0].responses;
+    expect(Object.keys(responses).sort()).toEqual(['200', 'default']);
+    expect(responses['default'].schema).toBeTruthy();
+  });
+});
+
 describe('buildEndpoints — empty response blocks', () => {
   beforeEach(() => {
     vi.resetAllMocks();

--- a/packages/omg-parser/src/resolver.ts
+++ b/packages/omg-parser/src/resolver.ts
@@ -493,7 +493,7 @@ function buildExpandedEndpoints(
     );
 
     // Build responses map
-    const responses: Record<number, ParsedResponse> = {};
+    const responses: Record<string, ParsedResponse> = {};
 
     for (const returnsBlock of returnsBlocks) {
       if (returnsBlock.parsedResponses) {
@@ -572,7 +572,7 @@ function buildSingleEndpoint(
   const exampleBlocks = doc.resolvedBlocks.filter((b) => b.type === 'omg.example');
 
   // Build responses map with conditions and descriptions
-  const responses: Record<number, ParsedResponse> = {};
+  const responses: Record<string, ParsedResponse> = {};
 
   // First, process omg.returns blocks (new conditional syntax)
   for (const returnsBlock of returnsBlocks) {

--- a/packages/omg-parser/src/types.ts
+++ b/packages/omg-parser/src/types.ts
@@ -191,7 +191,10 @@ export interface WhenCondition {
 // Parsed code block
 export interface OmgBlock {
   type: OmgBlockType;
-  statusCode?: number; // For omg.response.201, omg.example.201, etc.
+  // For omg.response.201, omg.example.201, etc. The string literal 'default'
+  // is the OpenAPI catch-all (omg.response.default), preserved through the
+  // pipeline as a non-numeric status code.
+  statusCode?: number | 'default';
   content: string;
   parsed?: OmgSchema; // Parsed schema (after OMG parsing)
   parsedResponses?: ParsedReturnsBlock; // For omg.returns blocks
@@ -382,7 +385,10 @@ export interface ParsedEndpoint {
     headers: OmgSchema | null;
   };
   requestBody: OmgSchema | null;
-  responses: Record<number, ParsedResponse>;
+  // Keyed by status code as a string ('200', '404') or 'default' for the
+  // OpenAPI catch-all. Stringly typed because OpenAPI's responses map uses
+  // string keys and 'default' is a valid OpenAPI key alongside numerics.
+  responses: Record<string, ParsedResponse>;
   /** Operation-level security requirements */
   security?: OmgSecurityRequirement[];
   /** External documentation */


### PR DESCRIPTION
## Summary

OpenAPI's `responses.default` (the catch-all key for any status not otherwise listed) was silently dropped during \`omg import\` because the importer filtered numeric-only with \`!isNaN(parseInt(statusCode))\`, and the parser's response-block regex only accepted digits.

End-to-end support added:

- **Parser**: \`OMG_BLOCK_PATTERN\` now matches \`omg.response.default\` alongside numerics. \`OmgBlock.statusCode\` widens to \`number | 'default' | undefined\`. The parser keeps 'default' as a string literal instead of parseInt-ing it to NaN.
- **Resolver / types**: \`ParsedEndpoint.responses\` keys are now strings (\`Record<string, ParsedResponse>\`) — already the source of truth at the OpenAPI YAML/JSON boundary, so this aligns the internal model.
- **Compiler**: emits 'Default response' as the description fallback when a default response has no explicit description.
- **Importer**: passes 'default' through to \`OmgBlock.statusCode\` instead of dropping the entire response.

## Impact on Weavr's Multi API round-trip

|   | before | after |
| --- | --- | --- |
| missing `default` responses | 124 | **0** |
| total response gap (across 134 ops) | 124 | **0** |

Combined with #78 (#76/#77), the bundled spec is now structurally complete for every operation in OPC's source: 0 param gap, 0 response gap, 0 operation gap on shared ops.

## Tests

New resolver test: \`omg.response.default\` parses and stores under the string key 'default'. All existing tests pass: parser (132), importer (72), compiler (6), md-cli (20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)