### PR TITLE
feat(importer): warn when input OpenAPI spec is fully dereferenced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `omg import` now warns when the input OpenAPI spec appears to be fully dereferenced — `components.schemas` is populated but no `$ref` is used anywhere. The warning recommends bundling the spec (e.g. `redocly bundle`, `swagger-cli bundle` without `-r`) instead of dereferencing it, since references are then preserved natively rather than recovered by structural matching. (#81)
+
 ## [0.4.2] - 2026-05-14
 
 ### Fixed

--- a/packages/omg-importer/src/importer.test.ts
+++ b/packages/omg-importer/src/importer.test.ts
@@ -493,6 +493,83 @@ describe('importOpenApi', () => {
       const types = (parentType?.schema as any).types;
       expect(types.some((t: any) => t.kind === 'reference' && t.name === 'Child')).toBe(true);
     });
+
+    describe('dereferenced-input warning', () => {
+      // #81 fix #2: detect a fully dereferenced input (components.schemas
+      // populated but zero $ref anywhere) and recommend bundling instead.
+      it('warns when components.schemas is populated but no $ref is used', () => {
+        const spec: OpenApiSpec = {
+          ...minimalSpec,
+          paths: {
+            '/users': {
+              post: {
+                operationId: 'create-user',
+                requestBody: {
+                  content: {
+                    'application/json': { schema: structuredClone(userSchema) },
+                  },
+                },
+              },
+            },
+          },
+          components: {
+            schemas: { User: structuredClone(userSchema) },
+          },
+        };
+
+        const result = importOpenApi(spec);
+
+        const warning = result.warnings.find((w) => w.message.includes('fully dereferenced'));
+        expect(warning).toBeDefined();
+        expect(warning?.message).toContain('redocly bundle');
+      });
+
+      it('does not warn when the spec uses $ref (a bundled input)', () => {
+        const spec: OpenApiSpec = {
+          ...minimalSpec,
+          paths: {
+            '/users': {
+              post: {
+                operationId: 'create-user',
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: { $ref: '#/components/schemas/User' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          components: {
+            schemas: { User: structuredClone(userSchema) },
+          },
+        };
+
+        const result = importOpenApi(spec);
+
+        expect(result.warnings.some((w) => w.message.includes('fully dereferenced'))).toBe(false);
+      });
+
+      it('does not warn when there are no component schemas', () => {
+        const result = importOpenApi(minimalSpec);
+
+        expect(result.warnings.some((w) => w.message.includes('fully dereferenced'))).toBe(false);
+      });
+
+      it('does not warn when inlineRefs is requested', () => {
+        const spec: OpenApiSpec = {
+          ...minimalSpec,
+          components: {
+            schemas: { User: structuredClone(userSchema) },
+          },
+        };
+
+        const result = importOpenApi(spec, { inlineRefs: true });
+
+        expect(result.warnings.some((w) => w.message.includes('fully dereferenced'))).toBe(false);
+      });
+    });
   });
 
   describe('warnings', () => {

--- a/packages/omg-importer/src/importer.ts
+++ b/packages/omg-importer/src/importer.ts
@@ -41,6 +41,7 @@ import { isReferenceObject } from './types.js';
 import {
   convertSchema,
   createConversionContext,
+  isStructurallyNamed,
   type ConversionContext,
 } from './schema-converter.js';
 import {
@@ -109,9 +110,21 @@ export function importOpenApi(spec: OpenApiSpec, options: ImportOptions = {}): I
   const partialThreshold = options.partialThreshold ?? 3;
   const partialCategories = options.partialCategories ?? ['header', 'query'];
 
+  const inlineRefs = options.inlineRefs ?? false;
   const ctx = createConversionContext(spec.components?.schemas || {}, {
-    inlineRefs: options.inlineRefs ?? false,
+    inlineRefs,
   });
+
+  // Warn when the input looks fully dereferenced: components.schemas is
+  // populated with reusable shapes, yet not a single $ref appears anywhere.
+  // The structural-dedup pass recovers most references, but bundling the
+  // spec (instead of dereferencing it) avoids relying on that heuristic.
+  if (!inlineRefs) {
+    const dereferenceWarning = detectDereferencedInput(spec);
+    if (dereferenceWarning) {
+      warnings.push({ message: dereferenceWarning });
+    }
+  }
 
   // Phase 1: Detect patterns (if extraction enabled)
   let detectedPatterns = new Map<string, DetectedPattern>();
@@ -164,6 +177,48 @@ export function importOpenApi(spec: OpenApiSpec, options: ImportOptions = {}): I
     partials: partialsMap,
     patternToPartial,
   };
+}
+
+/**
+ * Detect whether the input spec appears to have been fully dereferenced.
+ *
+ * A dereferenced spec (the default output of `swagger-cli bundle -r`,
+ * `redocly bundle --dereferenced`, and most Java/dotnet bundlers) inlines a
+ * structural copy of every schema at each usage site while still leaving
+ * `components.schemas` populated for browsability. The tell-tale signs are:
+ * `components.schemas` defines reusable shapes, yet not a single `$ref`
+ * appears anywhere in the document.
+ *
+ * Returns a one-line warning message recommending a bundle (not a
+ * dereference) of the input, or `null` if the spec looks fine.
+ */
+function detectDereferencedInput(spec: OpenApiSpec): string | null {
+  const schemas = spec.components?.schemas || {};
+  const namedShapes = Object.values(schemas).filter(
+    (s) => !isReferenceObject(s) && isStructurallyNamed(s)
+  ).length;
+
+  if (namedShapes === 0) return null;
+  if (containsRef(spec)) return null;
+
+  return (
+    `Input appears to be fully dereferenced: components.schemas defines ${namedShapes} ` +
+    `reusable schema(s) but no $ref is used anywhere. Inline schemas matching a named ` +
+    `component were recovered as references automatically; for a cleaner import, bundle ` +
+    `the spec without dereferencing it (e.g. \`redocly bundle\` instead of ` +
+    `\`redocly bundle --dereferenced\`, or \`swagger-cli bundle\` without \`-r\`).`
+  );
+}
+
+/**
+ * Recursively check whether a value contains any `$ref` property.
+ */
+function containsRef(value: unknown): boolean {
+  if (value === null || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some(containsRef);
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.$ref === 'string') return true;
+  return Object.values(obj).some(containsRef);
 }
 
 /**

--- a/packages/omg-importer/src/schema-converter.ts
+++ b/packages/omg-importer/src/schema-converter.ts
@@ -95,7 +95,7 @@ function buildFingerprintMap(
  * string`) are excluded so we don't replace every string field with a
  * reference to some `String` component.
  */
-function isStructurallyNamed(schema: SchemaObject): boolean {
+export function isStructurallyNamed(schema: SchemaObject): boolean {
   if (schema.allOf || schema.oneOf || schema.anyOf || schema.not) return true;
   if (schema.properties && Object.keys(schema.properties).length > 0) return true;
   if (schema.items) return true;


### PR DESCRIPTION
## Summary

Implements suggested fix #2 from #81. `omg import` now detects fully dereferenced input specs and warns the user, recommending they bundle instead.

A fully dereferenced spec — the default output of `swagger-cli bundle -r`, `redocly bundle --dereferenced`, and most Java/dotnet bundlers — has `components.schemas` populated for browsability but inlines a structural copy of every schema at each usage site, with no `$ref` anywhere. Suggested fix #1 (structural-dedup, shipped in 0.4.1, commit `7bb9d90`) already recovers most references from such inputs by shape-matching, but relying on a heuristic is fragile. This warning points users at the real fix: bundle the spec rather than dereference it.

## Behaviour

- Warns when `components.schemas` defines structurally-named shapes **and** the entire document contains zero `$ref`.
- Does **not** warn for bundled inputs (any `$ref` present), specs with no component schemas, or when `--inline` is requested (inlining is then intended).
- The warning surfaces through the existing CLI warnings output — no CLI changes needed.

Example output:

```
Warnings (1):
  ⚠ Input appears to be fully dereferenced: components.schemas defines 1 reusable schema(s)
    but no $ref is used anywhere. ... for a cleaner import, bundle the spec without
    dereferencing it (e.g. `redocly bundle` instead of `redocly bundle --dereferenced`...).
```

## Testing

- 4 new tests in `importer.test.ts` covering warn / no-warn cases.
- Full suite green; verified end-to-end via `omg import --dry-run` on a dereferenced fixture.

Note: suggested fix #3 (built-in bundling for file-fragmented inputs) remains open and is left for a follow-up.

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)