### PR TITLE
feat(test): add `omg test` contract-testing command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `omg test` command — contract testing that validates a live API against its OMG spec. For every endpoint it builds a request (resolving path/query/header parameters from `--env` files, declared examples, or generated placeholders), sends it to the `--against` base URL, and checks the response status code and body against the declared responses (JSON Schema validation via `ajv`, including `#/components/schemas` `$ref` resolution). Supports bearer / basic / custom-header auth, endpoint filtering (`-e`), retries and timeouts, and `console` / `json` / `junit` report formats (`--report`, `-o`) for CI. Exits non-zero when any test fails. Ships in the new private `omg-test` package, bundled into `omg-md-cli`. (#86)
 - `omg import` now warns when the input OpenAPI spec appears to be fully dereferenced — `components.schemas` is populated but no `$ref` is used anywhere. The warning recommends bundling the spec (e.g. `redocly bundle`, `swagger-cli bundle` without `-r`) instead of dereferencing it, since references are then preserved natively rather than recovered by structural matching. (#81)
 
 ## [0.4.2] - 2026-05-14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ omg/
 │   │   ├── src/
 │   │   │   ├── cli.ts               # Entry point (registers commands)
 │   │   │   ├── index.ts             # Package exports
-│   │   │   └── commands/            # One file per command (build, parse, lint, fmt, init, import, mock, diff, breaking, changelog) + shared utils.ts
+│   │   │   └── commands/            # One file per command (build, parse, lint, fmt, init, import, mock, diff, breaking, changelog, test) + shared utils.ts
 │   │   ├── build.mjs                # esbuild config for bundling private workspace deps
 │   │   └── dist/
 │   │
@@ -92,6 +92,16 @@ omg/
 │   │   │   ├── mock-generator.ts    # Mock data generation from schemas
 │   │   │   ├── vague-generator.ts   # Vague-based data generation
 │   │   │   └── server.ts            # Express HTTP server
+│   │   └── dist/
+│   │
+│   ├── omg-test/               # private/internal - bundled into omg-md-cli at publish time
+│   │   ├── src/
+│   │   │   ├── index.ts             # Package exports
+│   │   │   ├── runner.ts            # Contract test orchestration
+│   │   │   ├── request-builder.ts   # Builds HTTP requests from endpoint specs
+│   │   │   ├── validator.ts         # Response validation via ajv (JSON Schema)
+│   │   │   ├── reporter.ts          # Output formatting (console / json / junit)
+│   │   │   └── types.ts             # TypeScript type definitions
 │   │   └── dist/
 │   │
 │   └── omg-vscode/             # VS Code extension for syntax highlighting + LSP client
@@ -244,6 +254,12 @@ node packages/omg-md-cli/dist/cli.js changelog v1/api.omg.md v2/api.omg.md
 
 # Import OpenAPI to OMG format
 node packages/omg-md-cli/dist/cli.js import openapi.yaml -o my-api/
+
+# Run contract tests against a live API
+node packages/omg-md-cli/dist/cli.js test my-api/api.omg.md --against https://api.example.com --auth "$TOKEN"
+
+# Contract tests with a JUnit report for CI
+node packages/omg-md-cli/dist/cli.js test my-api/api.omg.md --against https://api.example.com --report junit -o results.xml
 ```
 
 ## Code Conventions
@@ -276,6 +292,7 @@ Private workspace packages, bundled into the published ones at build time via `e
 omg-linter      → bundled into omg-md-cli and omg-lsp
 omg-importer    → bundled into omg-md-cli
 omg-mock-server → bundled into omg-md-cli
+omg-test        → bundled into omg-md-cli (depends on omg-parser, omg-compiler, ajv)
 ```
 
 Packages use semver references (e.g., `^0.4.2`) for npm dependencies — all published packages currently share a single version line, bumped together at release time.

--- a/docusaurus/docs/cli/index.md
+++ b/docusaurus/docs/cli/index.md
@@ -31,6 +31,7 @@ npx omg-md-cli <command>
 | [`diff`](/docs/cli/change-management#diff) | Compare two API specifications |
 | [`breaking`](/docs/cli/change-management#breaking) | Detect breaking changes |
 | [`changelog`](/docs/cli/change-management#changelog) | Generate API changelog |
+| [`test`](/docs/cli/test) | Contract-test a live API against its spec |
 
 ## Quick reference
 
@@ -61,6 +62,9 @@ omg breaking old.omg.md new.omg.md --fail-on-diff
 
 # Generate changelog
 omg changelog v1/api.omg.md v2/api.omg.md
+
+# Contract-test a live API against its spec
+omg test api.omg.md --against https://api.example.com
 ```
 
 ## Global options

--- a/docusaurus/docs/cli/test.md
+++ b/docusaurus/docs/cli/test.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 7
+description: Run contract tests that validate a live API against its OMG specification.
+---
+
+# Test
+
+Run contract tests against a live API. `omg test` compiles your OMG spec, sends a
+request to every endpoint, and checks that the responses match what the spec
+declares.
+
+```bash
+omg test <input> --against <url> [options]
+```
+
+## What it checks
+
+For each endpoint in the spec, `omg test`:
+
+1. **Builds a request** — substitutes path, query, and header parameters from
+   `--env` values, declared examples, or generated placeholders. Endpoints whose
+   required parameters cannot be resolved are reported as **skipped** rather than
+   failed.
+2. **Sends it** to the `--against` base URL (with retries on network failure).
+3. **Validates the status code** against the declared responses.
+4. **Validates the response body** against the declared schema using JSON Schema
+   (`ajv`), including `#/components/schemas` `$ref` resolution.
+
+The command exits with a non-zero status if any test fails, so it can gate CI.
+
+## Examples
+
+```bash
+# Test every endpoint against a running API
+omg test api.omg.md --against https://api.example.com
+
+# Authenticate with a bearer token
+omg test api.omg.md --against https://api.example.com --auth "$TOKEN"
+
+# Test a single endpoint
+omg test api.omg.md --against https://api.example.com -e "GET /todos/{id}"
+
+# Emit a JUnit report for CI
+omg test api.omg.md --against https://api.example.com --report junit -o results.xml
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-a, --against <url>` | **Required.** Base URL of the API to test against |
+| `--auth <token>` | Bearer token for the `Authorization` header |
+| `--auth-header <name:value>` | Custom auth header, e.g. `X-API-Key:secret` |
+| `--basic-auth <user:password>` | HTTP basic auth credentials |
+| `-e, --endpoint <endpoints...>` | Filter to specific endpoints by `operationId`, path, or `METHOD /path` |
+| `--env <file>` | `.env`-style file supplying parameter values |
+| `-H, --header <headers...>` | Extra headers sent with every request |
+| `-t, --timeout <ms>` | Request timeout in milliseconds (default `30000`) |
+| `-r, --retries <count>` | Retries on network failure (default `2`) |
+| `--report <format>` | Output format: `console`, `json`, or `junit` (default `console`) |
+| `-o, --output <file>` | Write the report to a file instead of stdout |
+| `-v, --verbose` | Verbose output, including passing checks |
+
+## Supplying parameter values
+
+Path and query parameters are resolved, in order, from:
+
+1. The `--env` file — by exact name or `UPPER_SNAKE_CASE` (`thingId` → `THING_ID`).
+2. An `example` declared on the parameter or its schema.
+3. A `default` declared on the schema.
+4. A generated placeholder for common formats (`uuid`, `email`, `date`, IDs).
+
+An `.env` file looks like:
+
+```bash
+# values used to fill {accountId} and ?limit=
+ACCOUNT_ID=acc_12345
+limit=10
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -4529,6 +4529,10 @@
       "resolved": "packages/omg-parser",
       "link": true
     },
+    "node_modules/omg-test": {
+      "resolved": "packages/omg-test",
+      "link": true
+    },
     "node_modules/omg-vscode": {
       "resolved": "packages/omg-vscode",
       "link": true
@@ -6808,6 +6812,7 @@
         "omg-importer": "^0.4.2",
         "omg-linter": "^0.4.2",
         "omg-mock-server": "^0.4.2",
+        "omg-test": "^0.4.2",
         "typescript": "^5.3.0",
         "vitest": "^1.0.0"
       }
@@ -7303,6 +7308,21 @@
         "remark-parse": "^11.0.0",
         "unified": "^11.0.4",
         "unist-util-visit": "^5.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.3.0",
+        "vitest": "^1.0.0"
+      }
+    },
+    "packages/omg-test": {
+      "version": "0.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "omg-compiler": "^0.4.2",
+        "omg-parser": "^0.4.2"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build -w omg-parser && npm run build -w omg-compiler && npm run build -w omg-linter && npm run build -w omg-importer && npm run build -w omg-mock-server && npm run build -w omg-lsp && npm run build -w omg-md-cli",
+    "build": "npm run build -w omg-parser && npm run build -w omg-compiler && npm run build -w omg-linter && npm run build -w omg-importer && npm run build -w omg-mock-server && npm run build -w omg-test && npm run build -w omg-lsp && npm run build -w omg-md-cli",
     "test": "npm run test --workspaces",
     "typecheck": "npm run typecheck --workspaces",
     "prepare": "husky install",

--- a/packages/omg-md-cli/package.json
+++ b/packages/omg-md-cli/package.json
@@ -58,6 +58,7 @@
     "esbuild": "^0.24.0",
     "omg-linter": "^0.4.2",
     "omg-importer": "^0.4.2",
-    "omg-mock-server": "^0.4.2"
+    "omg-mock-server": "^0.4.2",
+    "omg-test": "^0.4.2"
   }
 }

--- a/packages/omg-md-cli/src/cli.ts
+++ b/packages/omg-md-cli/src/cli.ts
@@ -18,6 +18,7 @@ import {
   registerDiffCommand,
   registerBreakingCommand,
   registerChangelogCommand,
+  registerTestCommand,
 } from './commands/index.js';
 
 const program = new Command();
@@ -38,5 +39,6 @@ registerMockCommand(program);
 registerDiffCommand(program);
 registerBreakingCommand(program);
 registerChangelogCommand(program);
+registerTestCommand(program);
 
 program.parse();

--- a/packages/omg-md-cli/src/commands/index.ts
+++ b/packages/omg-md-cli/src/commands/index.ts
@@ -14,3 +14,4 @@ export { registerMockCommand } from './mock.js';
 export { registerDiffCommand } from './diff.js';
 export { registerBreakingCommand } from './breaking.js';
 export { registerChangelogCommand } from './changelog.js';
+export { registerTestCommand } from './test.js';

--- a/packages/omg-md-cli/src/commands/test.ts
+++ b/packages/omg-md-cli/src/commands/test.ts
@@ -1,0 +1,147 @@
+/**
+ * Test command - Run contract tests against a live API
+ */
+
+import { Command } from 'commander';
+import * as fs from 'fs';
+import * as path from 'path';
+import chalk from 'chalk';
+import { runContractTests, formatResults, type ReportFormat, type AuthConfig } from 'omg-test';
+import { validatePath, handleError } from './utils.js';
+
+interface TestOptions {
+  against: string;
+  auth?: string;
+  authHeader?: string;
+  basicAuth?: string;
+  endpoint?: string[];
+  env?: string;
+  header?: string[];
+  timeout?: string;
+  retries?: string;
+  report?: string;
+  output?: string;
+  verbose?: boolean;
+}
+
+/**
+ * Parse an .env-style file into a key/value record
+ */
+function parseEnvFile(content: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const [key, ...valueParts] = trimmed.split('=');
+    if (key) {
+      env[key.trim()] = valueParts.join('=').trim();
+    }
+  }
+  return env;
+}
+
+/**
+ * Parse `Name: value` style header strings into a record
+ */
+function parseHeaders(raw: string[] | undefined): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const h of raw ?? []) {
+    const [name, ...valueParts] = h.split(':');
+    if (name) {
+      headers[name.trim()] = valueParts.join(':').trim();
+    }
+  }
+  return headers;
+}
+
+/**
+ * Build an AuthConfig from the mutually-exclusive auth options
+ */
+function resolveAuth(options: TestOptions): AuthConfig | undefined {
+  if (options.auth) {
+    return { type: 'bearer', value: options.auth };
+  }
+  if (options.basicAuth) {
+    return { type: 'basic', value: Buffer.from(options.basicAuth).toString('base64') };
+  }
+  if (options.authHeader) {
+    const [name, ...valueParts] = options.authHeader.split(':');
+    return { type: 'header', headerName: name, value: valueParts.join(':').trim() };
+  }
+  return undefined;
+}
+
+export function registerTestCommand(program: Command): void {
+  program
+    .command('test <input>')
+    .description('Run contract tests against a live API')
+    .requiredOption('-a, --against <url>', 'Base URL of the API to test against')
+    .option('--auth <token>', 'Bearer token for authentication')
+    .option('--auth-header <name:value>', 'Custom auth header (e.g., "X-API-Key:secret")')
+    .option('--basic-auth <credentials>', 'Basic auth credentials (user:password)')
+    .option('-e, --endpoint <endpoints...>', 'Filter to specific endpoints (operationId or path)')
+    .option('--env <file>', 'Environment file with parameter values')
+    .option('-H, --header <headers...>', 'Additional headers (e.g., "X-Custom: value")')
+    .option('-t, --timeout <ms>', 'Request timeout in milliseconds', '30000')
+    .option('-r, --retries <count>', 'Number of retries on network failure', '2')
+    .option('--report <format>', 'Output format: console, json, junit', 'console')
+    .option('-o, --output <file>', 'Write report to file instead of stdout')
+    .option('-v, --verbose', 'Verbose output')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ omg test api.omg.md --against https://api.example.com
+  $ omg test api.omg.md --against $URL --auth "$TOKEN"
+  $ omg test api.omg.md --against $URL --report junit -o results.xml`
+    )
+    .action(async (input: string, options: TestOptions) => {
+      try {
+        const inputPath = path.resolve(input);
+        validatePath(inputPath);
+
+        const auth = resolveAuth(options);
+
+        let env: Record<string, string> | undefined;
+        if (options.env) {
+          const envPath = path.resolve(options.env);
+          if (fs.existsSync(envPath)) {
+            env = parseEnvFile(fs.readFileSync(envPath, 'utf-8'));
+          } else {
+            console.error(chalk.yellow(`Warning: Environment file not found: ${envPath}`));
+          }
+        }
+
+        const headers = parseHeaders(options.header);
+
+        console.error(chalk.blue(`Running contract tests against ${options.against}...`));
+
+        const summary = await runContractTests(inputPath, {
+          baseUrl: options.against,
+          auth,
+          endpoints: options.endpoint,
+          env,
+          headers,
+          timeout: parseInt(options.timeout || '30000', 10),
+          retries: parseInt(options.retries || '2', 10),
+          verbose: options.verbose,
+        });
+
+        const reportFormat = (options.report || 'console') as ReportFormat;
+        const output = formatResults(summary, reportFormat, options.verbose);
+
+        if (options.output) {
+          fs.writeFileSync(options.output, output);
+          console.error(chalk.green(`✓ Report written to ${options.output}`));
+        } else {
+          console.log(output);
+        }
+
+        if (summary.failed > 0) {
+          process.exit(1);
+        }
+      } catch (error) {
+        handleError(error);
+      }
+    });
+}

--- a/packages/omg-test/package.json
+++ b/packages/omg-test/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "omg-test",
+  "version": "0.4.2",
+  "private": true,
+  "description": "Contract testing for OMG (OpenAPI Markdown Grammar) - validate live APIs against specs",
+  "author": "mcclowes",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mcclowes/omg.git",
+    "directory": "packages/omg-test"
+  },
+  "bugs": {
+    "url": "https://github.com/mcclowes/omg/issues"
+  },
+  "homepage": "https://github.com/mcclowes/omg/tree/main/packages/omg-test#readme",
+  "keywords": [
+    "openapi",
+    "omg",
+    "contract-testing",
+    "api-testing",
+    "validation",
+    "api",
+    "specification"
+  ],
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "omg-parser": "^0.4.2",
+    "omg-compiler": "^0.4.2",
+    "ajv": "^8.12.0",
+    "ajv-formats": "^3.0.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/packages/omg-test/src/index.ts
+++ b/packages/omg-test/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * OMG Contract Testing
+ *
+ * Validate live APIs against OMG specifications.
+ *
+ * @example
+ * ```typescript
+ * import { runContractTests, formatResults } from 'omg-test';
+ *
+ * const summary = await runContractTests('api.omg.md', {
+ *   baseUrl: 'https://api.example.com',
+ *   auth: { type: 'bearer', value: 'your-token' },
+ * });
+ *
+ * console.log(formatResults(summary, 'console'));
+ * ```
+ */
+
+export { runContractTests } from './runner.js';
+export { formatResults } from './reporter.js';
+export { buildRequest, extractEndpoints } from './request-builder.js';
+export { validateResponse, validateStatusCode, validateRequiredFields } from './validator.js';
+
+export type {
+  TestOptions,
+  TestResult,
+  TestSummary,
+  CheckResult,
+  AuthConfig,
+  EndpointSpec,
+  ParameterSpec,
+  RequestBodySpec,
+  ResponseSpec,
+  SchemaSpec,
+  ReportFormat,
+} from './types.js';

--- a/packages/omg-test/src/reporter.test.ts
+++ b/packages/omg-test/src/reporter.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { formatResults } from './reporter.js';
+import type { TestSummary } from './types.js';
+
+function summary(overrides: Partial<TestSummary> = {}): TestSummary {
+  return {
+    total: 1,
+    passed: 1,
+    failed: 0,
+    skipped: 0,
+    duration: 1234,
+    results: [
+      {
+        operationId: 'get-thing',
+        method: 'GET',
+        path: '/things',
+        passed: true,
+        duration: 12,
+        checks: [{ name: 'Status code', passed: true, message: 'ok' }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('formatResults - json', () => {
+  it('produces parseable JSON containing the summary', () => {
+    const output = formatResults(summary(), 'json');
+    expect(JSON.parse(output)).toMatchObject({ total: 1, passed: 1 });
+  });
+});
+
+describe('formatResults - console', () => {
+  it('shows pass and fail counts', () => {
+    const output = formatResults(summary({ passed: 1, failed: 1, total: 2 }), 'console');
+    expect(output).toContain('1 passed');
+    expect(output).toContain('1 failed');
+  });
+});
+
+describe('formatResults - junit', () => {
+  it('emits a testsuite with the right counts', () => {
+    const output = formatResults(summary(), 'junit');
+    expect(output).toContain('<?xml version="1.0"');
+    expect(output).toContain('<testsuite name="Contract Tests" tests="1" failures="0"');
+    expect(output).toContain('<testcase name="GET /things"');
+  });
+
+  it('renders a failure element for a failed test', () => {
+    const failing = summary({
+      passed: 0,
+      failed: 1,
+      results: [
+        {
+          operationId: 'get-thing',
+          method: 'GET',
+          path: '/things',
+          passed: false,
+          duration: 5,
+          checks: [{ name: 'Status code', passed: false, message: 'Unexpected status code' }],
+        },
+      ],
+    });
+    const output = formatResults(failing, 'junit');
+    expect(output).toContain('<failure message="Unexpected status code">');
+  });
+
+  it('escapes XML-sensitive characters in test names', () => {
+    const tricky = summary({
+      results: [
+        {
+          operationId: 'op',
+          method: 'GET',
+          path: '/a?b=<c>&d',
+          passed: true,
+          duration: 1,
+          checks: [],
+        },
+      ],
+    });
+    const output = formatResults(tricky, 'junit');
+    expect(output).toContain('/a?b=&lt;c&gt;&amp;d');
+    expect(output).not.toContain('/a?b=<c>&d');
+  });
+
+  it('renders a skipped element for a skipped test', () => {
+    const skippedSummary = summary({
+      passed: 0,
+      skipped: 1,
+      results: [
+        {
+          operationId: 'op',
+          method: 'POST',
+          path: '/things',
+          passed: false,
+          duration: 0,
+          checks: [],
+          error: 'Skipped: Missing required parameters: body',
+        },
+      ],
+    });
+    const output = formatResults(skippedSummary, 'junit');
+    expect(output).toContain('<skipped message=');
+  });
+});

--- a/packages/omg-test/src/reporter.ts
+++ b/packages/omg-test/src/reporter.ts
@@ -1,0 +1,200 @@
+/**
+ * Test Reporters
+ *
+ * Format test results for different output formats.
+ */
+
+import type { TestSummary, TestResult, ReportFormat } from './types.js';
+
+/**
+ * Format test results based on report type
+ */
+export function formatResults(
+  summary: TestSummary,
+  format: ReportFormat,
+  verbose: boolean = false
+): string {
+  switch (format) {
+    case 'json':
+      return formatJson(summary);
+    case 'junit':
+      return formatJunit(summary);
+    case 'console':
+    default:
+      return formatConsole(summary, verbose);
+  }
+}
+
+/**
+ * Console-friendly output with colors (via ANSI codes)
+ */
+function formatConsole(summary: TestSummary, verbose: boolean): string {
+  const lines: string[] = [];
+
+  // ANSI color codes
+  const green = '\x1b[32m';
+  const red = '\x1b[31m';
+  const yellow = '\x1b[33m';
+  const gray = '\x1b[90m';
+  const reset = '\x1b[0m';
+  const bold = '\x1b[1m';
+
+  lines.push('');
+
+  for (const result of summary.results) {
+    const icon = result.passed ? `${green}✓${reset}` : `${red}✗${reset}`;
+    const status = result.passed ? green : red;
+
+    lines.push(`${icon} ${status}${result.method} ${result.path}${reset}`);
+
+    if (result.error) {
+      lines.push(`  ${yellow}${result.error}${reset}`);
+      continue;
+    }
+
+    // Show checks
+    for (const check of result.checks) {
+      if (check.passed) {
+        if (verbose) {
+          lines.push(`  ${green}✓${reset} ${check.name}: ${check.message || 'passed'}`);
+        }
+      } else {
+        lines.push(`  ${red}✗${reset} ${check.name}: ${check.message}`);
+        if (check.path) {
+          lines.push(`    ${gray}Path: ${check.path}${reset}`);
+        }
+        if (check.expected !== undefined) {
+          lines.push(`    ${gray}Expected: ${formatValue(check.expected)}${reset}`);
+        }
+        if (check.actual !== undefined) {
+          lines.push(`    ${gray}Actual: ${formatValue(check.actual)}${reset}`);
+        }
+      }
+    }
+
+    if (verbose && result.response) {
+      lines.push(`  ${gray}Response: ${result.response.status} (${result.duration}ms)${reset}`);
+    }
+  }
+
+  lines.push('');
+
+  // Summary line
+  const summaryParts: string[] = [];
+  if (summary.passed > 0) {
+    summaryParts.push(`${green}${summary.passed} passed${reset}`);
+  }
+  if (summary.failed > 0) {
+    summaryParts.push(`${red}${summary.failed} failed${reset}`);
+  }
+  if (summary.skipped > 0) {
+    summaryParts.push(`${yellow}${summary.skipped} skipped${reset}`);
+  }
+
+  lines.push(`${bold}Tests:${reset} ${summaryParts.join(', ') || 'none'}`);
+  lines.push(`${bold}Time:${reset} ${(summary.duration / 1000).toFixed(2)}s`);
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+/**
+ * JSON output for programmatic consumption
+ */
+function formatJson(summary: TestSummary): string {
+  return JSON.stringify(summary, null, 2);
+}
+
+/**
+ * JUnit XML output for CI/CD integration
+ */
+function formatJunit(summary: TestSummary): string {
+  const lines: string[] = [];
+
+  lines.push('<?xml version="1.0" encoding="UTF-8"?>');
+  lines.push(
+    `<testsuite name="Contract Tests" tests="${summary.total}" failures="${summary.failed}" skipped="${summary.skipped}" time="${(summary.duration / 1000).toFixed(3)}">`
+  );
+
+  for (const result of summary.results) {
+    const testName = escapeXml(`${result.method} ${result.path}`);
+    const className = escapeXml(result.operationId);
+    const time = (result.duration / 1000).toFixed(3);
+
+    lines.push(`  <testcase name="${testName}" classname="${className}" time="${time}">`);
+
+    if (result.error?.startsWith('Skipped:')) {
+      lines.push(`    <skipped message="${escapeXml(result.error)}"/>`);
+    } else if (!result.passed) {
+      const failedChecks = result.checks.filter((c) => !c.passed);
+      const message = result.error || failedChecks.map((c) => c.message).join('; ');
+      const details = formatFailureDetails(result);
+
+      lines.push(`    <failure message="${escapeXml(message)}">`);
+      lines.push(`      ${escapeXml(details)}`);
+      lines.push('    </failure>');
+    }
+
+    lines.push('  </testcase>');
+  }
+
+  lines.push('</testsuite>');
+
+  return lines.join('\n');
+}
+
+/**
+ * Format failure details for JUnit
+ */
+function formatFailureDetails(result: TestResult): string {
+  const lines: string[] = [];
+
+  lines.push(`Endpoint: ${result.method} ${result.path}`);
+
+  if (result.request) {
+    lines.push(`Request URL: ${result.request.url}`);
+  }
+
+  if (result.response) {
+    lines.push(`Response Status: ${result.response.status}`);
+  }
+
+  lines.push('');
+  lines.push('Failed Checks:');
+
+  for (const check of result.checks) {
+    if (!check.passed) {
+      lines.push(`  - ${check.name}: ${check.message}`);
+      if (check.expected !== undefined) {
+        lines.push(`    Expected: ${formatValue(check.expected)}`);
+      }
+      if (check.actual !== undefined) {
+        lines.push(`    Actual: ${formatValue(check.actual)}`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Format a value for display
+ */
+function formatValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value === undefined) return 'undefined';
+  if (value === null) return 'null';
+  return JSON.stringify(value);
+}
+
+/**
+ * Escape special XML characters
+ */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}

--- a/packages/omg-test/src/request-builder.test.ts
+++ b/packages/omg-test/src/request-builder.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { buildRequest, extractEndpoints } from './request-builder.js';
+import type { EndpointSpec } from './types.js';
+
+function endpoint(overrides: Partial<EndpointSpec> = {}): EndpointSpec {
+  return {
+    operationId: 'op',
+    method: 'GET',
+    path: '/things',
+    parameters: [],
+    responses: { '200': { description: 'ok' } },
+    ...overrides,
+  };
+}
+
+describe('buildRequest', () => {
+  it('joins the base URL and path, trimming a trailing slash', () => {
+    const result = buildRequest(endpoint(), { baseUrl: 'https://api.test/' });
+    expect(result.request?.url).toBe('https://api.test/things');
+  });
+
+  it('substitutes path parameters from env values', () => {
+    const ep = endpoint({
+      path: '/things/{thingId}',
+      parameters: [{ name: 'thingId', in: 'path', required: true, schema: { type: 'string' } }],
+    });
+    const result = buildRequest(ep, { baseUrl: 'https://api.test', env: { thingId: '42' } });
+    expect(result.request?.url).toBe('https://api.test/things/42');
+  });
+
+  it('returns an error when a required path parameter cannot be resolved', () => {
+    const ep = endpoint({
+      path: '/things/{thingId}',
+      parameters: [{ name: 'thingId', in: 'path', required: true, schema: { type: 'object' } }],
+    });
+    const result = buildRequest(ep, { baseUrl: 'https://api.test' });
+    expect(result.request).toBeUndefined();
+    expect(result.missingParams).toContain('path.thingId');
+  });
+
+  it('appends required query parameters with declared examples', () => {
+    const ep = endpoint({
+      parameters: [
+        { name: 'limit', in: 'query', required: true, schema: { type: 'integer' }, example: 10 },
+      ],
+    });
+    const result = buildRequest(ep, { baseUrl: 'https://api.test' });
+    expect(result.request?.url).toBe('https://api.test/things?limit=10');
+  });
+
+  it('adds a bearer Authorization header', () => {
+    const result = buildRequest(endpoint(), {
+      baseUrl: 'https://api.test',
+      auth: { type: 'bearer', value: 'tok' },
+    });
+    expect(result.request?.headers.Authorization).toBe('Bearer tok');
+  });
+
+  it('adds a custom header for header-type auth', () => {
+    const result = buildRequest(endpoint(), {
+      baseUrl: 'https://api.test',
+      auth: { type: 'header', headerName: 'X-API-Key', value: 'secret' },
+    });
+    expect(result.request?.headers['X-API-Key']).toBe('secret');
+  });
+
+  it('serializes a request body from its example', () => {
+    const ep = endpoint({
+      method: 'POST',
+      requestBody: { required: true, schema: { type: 'object' }, example: { name: 'a' } },
+    });
+    const result = buildRequest(ep, { baseUrl: 'https://api.test' });
+    expect(result.request?.body).toBe('{"name":"a"}');
+    expect(result.request?.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('flags a required body with no example as missing', () => {
+    const ep = endpoint({
+      method: 'POST',
+      requestBody: { required: true, schema: { type: 'object' } },
+    });
+    const result = buildRequest(ep, { baseUrl: 'https://api.test' });
+    expect(result.missingParams).toContain('body');
+  });
+});
+
+describe('extractEndpoints', () => {
+  it('extracts an operation per method with parameters and responses', () => {
+    const endpoints = extractEndpoints({
+      paths: {
+        '/users/{id}': {
+          get: {
+            operationId: 'get-user',
+            parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+            responses: {
+              '200': {
+                description: 'ok',
+                content: { 'application/json': { schema: { $ref: '#/components/schemas/User' } } },
+              },
+            },
+          },
+        },
+      },
+      components: { schemas: { User: { type: 'object', required: ['id'] } } },
+    });
+
+    expect(endpoints).toHaveLength(1);
+    expect(endpoints[0].operationId).toBe('get-user');
+    expect(endpoints[0].method).toBe('GET');
+    expect(endpoints[0].parameters[0].name).toBe('id');
+    // $ref should be resolved against components.schemas
+    expect(endpoints[0].responses['200'].schema).toMatchObject({ type: 'object' });
+  });
+
+  it('falls back to a generated operationId when none is declared', () => {
+    const endpoints = extractEndpoints({
+      paths: { '/health': { get: { responses: { '200': { description: 'ok' } } } } },
+    });
+    expect(endpoints[0].operationId).toBe('get-/health');
+  });
+});

--- a/packages/omg-test/src/request-builder.ts
+++ b/packages/omg-test/src/request-builder.ts
@@ -1,0 +1,317 @@
+/**
+ * Request Builder
+ *
+ * Builds HTTP requests from OpenAPI endpoint specifications.
+ * Handles path parameters, query parameters, headers, and request bodies.
+ */
+
+import type { EndpointSpec, TestOptions, ParameterSpec } from './types.js';
+
+export interface BuiltRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+export interface RequestBuildResult {
+  request?: BuiltRequest;
+  error?: string;
+  missingParams?: string[];
+}
+
+/**
+ * Build an HTTP request from an endpoint spec
+ */
+export function buildRequest(endpoint: EndpointSpec, options: TestOptions): RequestBuildResult {
+  const missingParams: string[] = [];
+
+  // Start with base URL
+  let url = options.baseUrl.replace(/\/$/, '');
+
+  // Build path with parameter substitution
+  let path = endpoint.path;
+  const pathParams = endpoint.parameters.filter((p) => p.in === 'path');
+
+  for (const param of pathParams) {
+    const value = getParamValue(param, options);
+    if (value === undefined && param.required) {
+      missingParams.push(`path.${param.name}`);
+    } else if (value !== undefined) {
+      path = path.replace(`{${param.name}}`, encodeURIComponent(String(value)));
+    }
+  }
+
+  url += path;
+
+  // Add query parameters
+  const queryParams = endpoint.parameters.filter((p) => p.in === 'query');
+  const queryParts: string[] = [];
+
+  for (const param of queryParams) {
+    const value = getParamValue(param, options);
+    if (value === undefined && param.required) {
+      missingParams.push(`query.${param.name}`);
+    } else if (value !== undefined) {
+      queryParts.push(`${encodeURIComponent(param.name)}=${encodeURIComponent(String(value))}`);
+    }
+  }
+
+  if (queryParts.length > 0) {
+    url += '?' + queryParts.join('&');
+  }
+
+  // Build headers
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    ...options.headers,
+  };
+
+  // Add auth header
+  if (options.auth) {
+    switch (options.auth.type) {
+      case 'bearer':
+        headers['Authorization'] = `Bearer ${options.auth.value}`;
+        break;
+      case 'basic':
+        headers['Authorization'] = `Basic ${options.auth.value}`;
+        break;
+      case 'header':
+        headers[options.auth.headerName || 'X-API-Key'] = options.auth.value;
+        break;
+    }
+  }
+
+  // Add header parameters
+  const headerParams = endpoint.parameters.filter((p) => p.in === 'header');
+  for (const param of headerParams) {
+    const value = getParamValue(param, options);
+    if (value === undefined && param.required) {
+      missingParams.push(`header.${param.name}`);
+    } else if (value !== undefined) {
+      headers[param.name] = String(value);
+    }
+  }
+
+  // Build request body
+  let body: string | undefined;
+  if (endpoint.requestBody) {
+    if (endpoint.requestBody.example) {
+      body = JSON.stringify(endpoint.requestBody.example);
+      headers['Content-Type'] = 'application/json';
+    } else if (endpoint.requestBody.required) {
+      missingParams.push('body');
+    }
+  }
+
+  // If we have missing required params, return error
+  if (missingParams.length > 0) {
+    return {
+      error: `Missing required parameters: ${missingParams.join(', ')}`,
+      missingParams,
+    };
+  }
+
+  return {
+    request: {
+      url,
+      method: endpoint.method.toUpperCase(),
+      headers,
+      body,
+    },
+  };
+}
+
+/**
+ * Get the value for a parameter from options or examples
+ */
+function getParamValue(param: ParameterSpec, options: TestOptions): unknown {
+  // First check environment variables
+  if (options.env) {
+    // Try exact match
+    if (param.name in options.env) {
+      return options.env[param.name];
+    }
+    // Try UPPER_SNAKE_CASE
+    const upperName = toUpperSnakeCase(param.name);
+    if (upperName in options.env) {
+      return options.env[upperName];
+    }
+  }
+
+  // Then check for example in the parameter spec
+  if (param.example !== undefined) {
+    return param.example;
+  }
+
+  // Check schema for example
+  if (param.schema.example !== undefined) {
+    return param.schema.example;
+  }
+
+  // Check schema for default
+  if (param.schema.default !== undefined) {
+    return param.schema.default;
+  }
+
+  // Generate a placeholder for common patterns
+  return generatePlaceholder(param);
+}
+
+/**
+ * Convert camelCase to UPPER_SNAKE_CASE
+ */
+function toUpperSnakeCase(str: string): string {
+  return str.replace(/([a-z])([A-Z])/g, '$1_$2').toUpperCase();
+}
+
+/**
+ * Generate a placeholder value based on parameter schema
+ */
+function generatePlaceholder(param: ParameterSpec): unknown {
+  const schema = param.schema;
+  const type = schema.type as string;
+
+  // Check for enum - use first value
+  if (schema.enum && Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return schema.enum[0];
+  }
+
+  // Check for format hints
+  const format = schema.format as string;
+
+  switch (type) {
+    case 'string':
+      if (format === 'uuid') return 'test-uuid-0000-0000-000000000000';
+      if (format === 'email') return 'test@example.com';
+      if (format === 'date') return '2024-01-01';
+      if (format === 'date-time') return '2024-01-01T00:00:00Z';
+      if (format === 'uri' || format === 'url') return 'https://example.com';
+      // For IDs, try to generate something reasonable
+      if (param.name.toLowerCase().includes('id')) return 'test-id-123';
+      return undefined; // Don't guess arbitrary strings
+
+    case 'integer':
+    case 'number':
+      if (schema.minimum !== undefined) return schema.minimum;
+      if (schema.maximum !== undefined) return schema.maximum;
+      return 1;
+
+    case 'boolean':
+      return true;
+
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Extract endpoint specifications from an OpenAPI document
+ */
+export function extractEndpoints(openapi: {
+  paths: Record<string, Record<string, unknown>>;
+  components?: { schemas?: Record<string, unknown> };
+}): EndpointSpec[] {
+  const endpoints: EndpointSpec[] = [];
+  const methods = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options'];
+
+  for (const [path, pathItem] of Object.entries(openapi.paths)) {
+    for (const method of methods) {
+      const operation = pathItem[method] as Record<string, unknown> | undefined;
+      if (!operation) continue;
+
+      const endpoint: EndpointSpec = {
+        operationId: (operation.operationId as string) || `${method}-${path}`,
+        method: method.toUpperCase(),
+        path,
+        summary: operation.summary as string | undefined,
+        parameters: extractParameters(operation, openapi),
+        requestBody: extractRequestBody(operation, openapi),
+        responses: extractResponses(operation, openapi),
+      };
+
+      endpoints.push(endpoint);
+    }
+  }
+
+  return endpoints;
+}
+
+function extractParameters(
+  operation: Record<string, unknown>,
+  openapi: { components?: { schemas?: Record<string, unknown> } }
+): ParameterSpec[] {
+  const params = (operation.parameters as Array<Record<string, unknown>>) || [];
+  return params.map((p) => ({
+    name: p.name as string,
+    in: p.in as 'path' | 'query' | 'header',
+    required: (p.required as boolean) ?? false,
+    schema: resolveSchema(p.schema as Record<string, unknown>, openapi),
+    example: p.example,
+  }));
+}
+
+function extractRequestBody(
+  operation: Record<string, unknown>,
+  openapi: { components?: { schemas?: Record<string, unknown> } }
+): { required: boolean; schema: Record<string, unknown>; example?: unknown } | undefined {
+  const body = operation.requestBody as Record<string, unknown> | undefined;
+  if (!body) return undefined;
+
+  const content = body.content as Record<string, Record<string, unknown>> | undefined;
+  if (!content) return undefined;
+
+  // Prefer application/json
+  const jsonContent = content['application/json'];
+  if (!jsonContent) return undefined;
+
+  return {
+    required: (body.required as boolean) ?? false,
+    schema: resolveSchema(jsonContent.schema as Record<string, unknown>, openapi),
+    example: jsonContent.example,
+  };
+}
+
+function extractResponses(
+  operation: Record<string, unknown>,
+  openapi: { components?: { schemas?: Record<string, unknown> } }
+): Record<string, { description: string; schema?: Record<string, unknown> }> {
+  const responses = (operation.responses as Record<string, Record<string, unknown>>) || {};
+  const result: Record<string, { description: string; schema?: Record<string, unknown> }> = {};
+
+  for (const [code, response] of Object.entries(responses)) {
+    const content = response.content as Record<string, Record<string, unknown>> | undefined;
+    const jsonContent = content?.['application/json'];
+
+    result[code] = {
+      description: (response.description as string) || '',
+      schema: jsonContent?.schema
+        ? resolveSchema(jsonContent.schema as Record<string, unknown>, openapi)
+        : undefined,
+    };
+  }
+
+  return result;
+}
+
+function resolveSchema(
+  schema: Record<string, unknown> | undefined,
+  openapi: { components?: { schemas?: Record<string, unknown> } }
+): Record<string, unknown> {
+  if (!schema) return {};
+
+  // Handle $ref
+  if (schema.$ref) {
+    const ref = schema.$ref as string;
+    const match = ref.match(/^#\/components\/schemas\/(.+)$/);
+    if (match && openapi.components?.schemas) {
+      const resolved = openapi.components.schemas[match[1]] as Record<string, unknown>;
+      if (resolved) {
+        return resolveSchema(resolved, openapi);
+      }
+    }
+    return schema;
+  }
+
+  return schema;
+}

--- a/packages/omg-test/src/runner.ts
+++ b/packages/omg-test/src/runner.ts
@@ -1,0 +1,269 @@
+/**
+ * Contract Test Runner
+ *
+ * Orchestrates contract tests against a live API.
+ */
+
+import { loadApi } from 'omg-parser';
+import { compileToOpenApi } from 'omg-compiler';
+import type { TestOptions, TestResult, TestSummary, EndpointSpec, CheckResult } from './types.js';
+import { buildRequest, extractEndpoints } from './request-builder.js';
+import { validateResponse, validateStatusCode, validateRequiredFields } from './validator.js';
+
+const DEFAULT_TIMEOUT = 30000;
+const DEFAULT_RETRIES = 2;
+
+/**
+ * Run contract tests against a live API
+ */
+export async function runContractTests(
+  inputPath: string,
+  options: TestOptions
+): Promise<TestSummary> {
+  const startTime = Date.now();
+  const results: TestResult[] = [];
+
+  // Load and compile OMG to OpenAPI
+  const api = loadApi(inputPath);
+  const openapi = compileToOpenApi(api);
+
+  // Extract testable endpoints
+  // Cast to the expected type - OpenAPI paths are compatible
+  const doc = openapi as unknown as {
+    paths: Record<string, Record<string, unknown>>;
+    components?: { schemas?: Record<string, unknown> };
+  };
+  const allEndpoints = extractEndpoints(doc);
+
+  // Filter endpoints if specified
+  const endpoints = filterEndpoints(allEndpoints, options.endpoints);
+
+  if (options.verbose) {
+    console.error(`Found ${endpoints.length} endpoint(s) to test`);
+  }
+
+  // Run tests for each endpoint
+  for (const endpoint of endpoints) {
+    const result = await testEndpoint(endpoint, options, doc.components);
+    results.push(result);
+  }
+
+  // Calculate summary
+  const summary: TestSummary = {
+    total: results.length,
+    passed: results.filter((r) => r.passed).length,
+    failed: results.filter((r) => !r.passed && !isSkipped(r)).length,
+    skipped: results.filter((r) => isSkipped(r)).length,
+    duration: Date.now() - startTime,
+    results,
+  };
+
+  return summary;
+}
+
+/**
+ * Test a single endpoint
+ */
+async function testEndpoint(
+  endpoint: EndpointSpec,
+  options: TestOptions,
+  components?: Record<string, unknown>
+): Promise<TestResult> {
+  const startTime = Date.now();
+  const checks: CheckResult[] = [];
+
+  // Build the request
+  const buildResult = buildRequest(endpoint, options);
+
+  if (buildResult.error || !buildResult.request) {
+    return {
+      operationId: endpoint.operationId,
+      method: endpoint.method,
+      path: endpoint.path,
+      passed: false,
+      duration: Date.now() - startTime,
+      checks: [],
+      error: `Skipped: ${buildResult.error}`,
+    };
+  }
+
+  const { request } = buildResult;
+
+  if (options.verbose) {
+    console.error(`Testing ${endpoint.method} ${endpoint.path}...`);
+    console.error(`  URL: ${request.url}`);
+  }
+
+  // Execute the request with retries
+  let response: Response | undefined;
+  let lastError: Error | undefined;
+
+  const maxRetries = options.retries ?? DEFAULT_RETRIES;
+  const timeout = options.timeout ?? DEFAULT_TIMEOUT;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+      response = await fetch(request.url, {
+        method: request.method,
+        headers: request.headers,
+        body: request.body,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+      break; // Success, exit retry loop
+    } catch (err) {
+      lastError = err as Error;
+      if (attempt < maxRetries) {
+        // Wait before retrying (exponential backoff)
+        await sleep(Math.pow(2, attempt) * 1000);
+      }
+    }
+  }
+
+  if (!response) {
+    return {
+      operationId: endpoint.operationId,
+      method: endpoint.method,
+      path: endpoint.path,
+      passed: false,
+      duration: Date.now() - startTime,
+      checks: [],
+      error: `Request failed after ${maxRetries + 1} attempts: ${lastError?.message}`,
+      request: {
+        url: request.url,
+        method: request.method,
+        headers: request.headers,
+        body: request.body ? JSON.parse(request.body) : undefined,
+      },
+    };
+  }
+
+  // Parse response body
+  let body: unknown;
+  const contentType = response.headers.get('content-type') || '';
+
+  if (contentType.includes('application/json')) {
+    try {
+      body = await response.json();
+    } catch {
+      body = await response.text();
+    }
+  } else {
+    body = await response.text();
+  }
+
+  // Get expected status codes
+  const expectedCodes = Object.keys(endpoint.responses)
+    .filter((code) => code !== 'default')
+    .map((code) => parseInt(code, 10));
+
+  const hasDefaultResponse = 'default' in endpoint.responses;
+
+  // Validate status code
+  const statusCheck = validateStatusCode(response.status, expectedCodes, hasDefaultResponse);
+  checks.push(statusCheck);
+
+  // Get the schema for this status code
+  const statusKey = String(response.status);
+  const responseSpec = endpoint.responses[statusKey] || endpoint.responses['default'];
+
+  if (responseSpec?.schema) {
+    // Validate required fields
+    const requiredChecks = validateRequiredFields(body, responseSpec.schema);
+    checks.push(...requiredChecks);
+
+    // Validate full schema
+    const schemaChecks = validateResponse(body, responseSpec.schema, response.status, components);
+    checks.push(...schemaChecks);
+  } else {
+    checks.push({
+      name: 'Schema validation',
+      passed: true,
+      message: `No schema defined for status ${response.status}, skipping body validation`,
+    });
+  }
+
+  // Determine overall pass/fail
+  const passed = checks.every((c) => c.passed);
+
+  // Build response headers record
+  const responseHeaders: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    responseHeaders[key] = value;
+  });
+
+  return {
+    operationId: endpoint.operationId,
+    method: endpoint.method,
+    path: endpoint.path,
+    passed,
+    duration: Date.now() - startTime,
+    checks,
+    request: {
+      url: request.url,
+      method: request.method,
+      headers: request.headers,
+      body: request.body ? JSON.parse(request.body) : undefined,
+    },
+    response: {
+      status: response.status,
+      headers: responseHeaders,
+      body,
+    },
+  };
+}
+
+/**
+ * A result is "skipped" when the request could not be built (e.g. missing
+ * required parameters), as opposed to a genuine assertion failure.
+ */
+function isSkipped(result: TestResult): boolean {
+  return result.error?.startsWith('Skipped:') ?? false;
+}
+
+/**
+ * Filter endpoints based on user criteria
+ */
+function filterEndpoints(endpoints: EndpointSpec[], filter?: string[]): EndpointSpec[] {
+  if (!filter || filter.length === 0) {
+    return endpoints;
+  }
+
+  return endpoints.filter((endpoint) => {
+    for (const f of filter) {
+      // Match by operationId
+      if (endpoint.operationId === f) return true;
+      // Match by path
+      if (endpoint.path === f) return true;
+      // Match by "METHOD /path" (e.g., "GET /health"); method is case-insensitive
+      const spaceIdx = f.indexOf(' ');
+      if (spaceIdx > 0) {
+        const fMethod = f.slice(0, spaceIdx).toUpperCase();
+        const fPath = f.slice(spaceIdx + 1).trim();
+        if (endpoint.method === fMethod && endpoint.path === fPath) return true;
+      }
+      // Match by glob pattern on path
+      if (f.includes('*') && matchGlob(endpoint.path, f)) return true;
+    }
+    return false;
+  });
+}
+
+/**
+ * Simple glob matching for paths
+ */
+function matchGlob(path: string, pattern: string): boolean {
+  const regex = pattern.replace(/\*/g, '.*').replace(/\?/g, '.');
+  return new RegExp(`^${regex}$`).test(path);
+}
+
+/**
+ * Sleep for a number of milliseconds
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/omg-test/src/types.ts
+++ b/packages/omg-test/src/types.ts
@@ -1,0 +1,104 @@
+/**
+ * Contract Testing Types
+ */
+
+export interface TestOptions {
+  /** Base URL of the API to test */
+  baseUrl: string;
+  /** Authentication configuration */
+  auth?: AuthConfig;
+  /** Filter to specific endpoints (operationIds or paths) */
+  endpoints?: string[];
+  /** Request timeout in milliseconds */
+  timeout?: number;
+  /** Number of retries on network failure */
+  retries?: number;
+  /** Verbose output */
+  verbose?: boolean;
+  /** Environment variables for path/query params */
+  env?: Record<string, string>;
+  /** Headers to include in all requests */
+  headers?: Record<string, string>;
+}
+
+export interface AuthConfig {
+  type: 'bearer' | 'basic' | 'header';
+  value: string;
+  /** Header name for 'header' type auth */
+  headerName?: string;
+}
+
+export interface TestResult {
+  operationId: string;
+  method: string;
+  path: string;
+  passed: boolean;
+  duration: number;
+  checks: CheckResult[];
+  error?: string;
+  request?: {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body?: unknown;
+  };
+  response?: {
+    status: number;
+    headers: Record<string, string>;
+    body?: unknown;
+  };
+}
+
+export interface CheckResult {
+  name: string;
+  passed: boolean;
+  message?: string;
+  expected?: unknown;
+  actual?: unknown;
+  path?: string;
+}
+
+export interface TestSummary {
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  duration: number;
+  results: TestResult[];
+}
+
+export interface EndpointSpec {
+  operationId: string;
+  method: string;
+  path: string;
+  summary?: string;
+  parameters: ParameterSpec[];
+  requestBody?: RequestBodySpec;
+  responses: Record<string, ResponseSpec>;
+}
+
+export interface ParameterSpec {
+  name: string;
+  in: 'path' | 'query' | 'header';
+  required: boolean;
+  schema: SchemaSpec;
+  example?: unknown;
+}
+
+export interface RequestBodySpec {
+  required: boolean;
+  schema: SchemaSpec;
+  example?: unknown;
+}
+
+export interface ResponseSpec {
+  description: string;
+  schema?: SchemaSpec;
+}
+
+export interface SchemaSpec {
+  // OpenAPI/JSON Schema object
+  [key: string]: unknown;
+}
+
+export type ReportFormat = 'console' | 'json' | 'junit';

--- a/packages/omg-test/src/validator.test.ts
+++ b/packages/omg-test/src/validator.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { validateResponse, validateStatusCode, validateRequiredFields } from './validator.js';
+
+describe('validateStatusCode', () => {
+  it('passes when the status is in the expected list', () => {
+    const check = validateStatusCode(200, [200, 404], false);
+    expect(check.passed).toBe(true);
+    expect(check.message).toContain('200');
+  });
+
+  it('fails when the status is not expected and there is no default response', () => {
+    const check = validateStatusCode(500, [200], false);
+    expect(check.passed).toBe(false);
+    expect(check.expected).toBe('200');
+    expect(check.actual).toBe(500);
+  });
+
+  it('passes an unexpected status when a default response is declared', () => {
+    const check = validateStatusCode(503, [200], true);
+    expect(check.passed).toBe(true);
+  });
+});
+
+describe('validateRequiredFields', () => {
+  const schema = { type: 'object', required: ['id', 'name'] };
+
+  it('passes when all required fields are present', () => {
+    const checks = validateRequiredFields({ id: '1', name: 'a' }, schema);
+    expect(checks).toHaveLength(1);
+    expect(checks[0].passed).toBe(true);
+  });
+
+  it('reports each missing required field', () => {
+    const checks = validateRequiredFields({ id: '1' }, schema);
+    expect(checks).toHaveLength(1);
+    expect(checks[0].passed).toBe(false);
+    expect(checks[0].message).toContain('name');
+    expect(checks[0].path).toBe('/name');
+  });
+
+  it('returns no checks for a non-object body', () => {
+    expect(validateRequiredFields('not-an-object', schema)).toEqual([]);
+  });
+
+  it('returns no checks when the schema has no required array', () => {
+    expect(validateRequiredFields({ id: '1' }, { type: 'object' })).toEqual([]);
+  });
+});
+
+describe('validateResponse', () => {
+  const schema = {
+    type: 'object',
+    properties: { id: { type: 'string' }, count: { type: 'integer' } },
+    required: ['id'],
+  };
+
+  it('passes when the body matches the schema', () => {
+    const checks = validateResponse({ id: 'abc', count: 3 }, schema, 200);
+    expect(checks).toHaveLength(1);
+    expect(checks[0].passed).toBe(true);
+  });
+
+  it('fails with a type error when a field has the wrong type', () => {
+    const checks = validateResponse({ id: 123 }, schema, 200);
+    expect(checks.some((c) => !c.passed)).toBe(true);
+    const failure = checks.find((c) => !c.passed);
+    expect(failure?.message).toContain('id');
+  });
+
+  it('skips validation when the schema is empty', () => {
+    const checks = validateResponse({ anything: true }, {}, 204);
+    expect(checks).toHaveLength(1);
+    expect(checks[0].passed).toBe(true);
+    expect(checks[0].name).toBe('Schema exists');
+  });
+
+  it('reports an enum violation in a readable way', () => {
+    const enumSchema = { type: 'string', enum: ['a', 'b'] };
+    const checks = validateResponse('c', enumSchema, 200);
+    const failure = checks.find((c) => !c.passed);
+    expect(failure?.message).toContain('must be one of');
+  });
+
+  it('resolves #/components/schemas $refs when components are provided', () => {
+    const refSchema = { $ref: '#/components/schemas/User' };
+    const components = {
+      schemas: {
+        User: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+      },
+    };
+
+    const ok = validateResponse({ id: 'abc' }, refSchema, 200, components);
+    expect(ok.every((c) => c.passed)).toBe(true);
+
+    const bad = validateResponse({ id: 42 }, refSchema, 200, components);
+    expect(bad.some((c) => !c.passed)).toBe(true);
+  });
+});

--- a/packages/omg-test/src/validator.ts
+++ b/packages/omg-test/src/validator.ts
@@ -1,0 +1,219 @@
+/**
+ * Response Validator
+ *
+ * Uses ajv (JSON Schema validator) to validate API responses against OpenAPI schemas.
+ * This is the "wrapper around existing tools" approach - ajv is battle-tested.
+ */
+
+import AjvModule, { type ErrorObject } from 'ajv';
+import addFormatsModule from 'ajv-formats';
+import type { CheckResult, SchemaSpec } from './types.js';
+
+// ajv and ajv-formats ship CommonJS. Under NodeNext module resolution the
+// default import resolves to the module namespace, so reach for `.default`
+// to get the real constructor / plugin function.
+const Ajv = AjvModule.default;
+const addFormats = addFormatsModule.default;
+
+// Create ajv instance with OpenAPI-compatible settings
+const ajv = new Ajv({
+  allErrors: true,
+  strict: false,
+  validateFormats: true,
+});
+
+addFormats(ajv);
+
+// Add OpenAPI-specific formats
+ajv.addFormat('int32', {
+  type: 'number',
+  validate: (x: number) => Number.isInteger(x) && x >= -2147483648 && x <= 2147483647,
+});
+ajv.addFormat('int64', {
+  type: 'number',
+  validate: (x: number) => Number.isInteger(x),
+});
+ajv.addFormat('float', { type: 'number', validate: () => true });
+ajv.addFormat('double', { type: 'number', validate: () => true });
+ajv.addFormat('decimal', { type: 'number', validate: () => true });
+
+/**
+ * Validate a response body against a JSON Schema
+ *
+ * `components` is the OpenAPI `components` object. When provided it is attached
+ * to the schema root so internal `#/components/schemas/...` `$ref`s resolve.
+ */
+export function validateResponse(
+  body: unknown,
+  schema: SchemaSpec,
+  statusCode: number,
+  components?: Record<string, unknown>
+): CheckResult[] {
+  const checks: CheckResult[] = [];
+
+  // Check if we have a schema to validate against
+  if (!schema || Object.keys(schema).length === 0) {
+    checks.push({
+      name: 'Schema exists',
+      passed: true,
+      message: `No schema defined for ${statusCode}, skipping body validation`,
+    });
+    return checks;
+  }
+
+  // Attach components so `#/components/schemas/...` $refs resolve via JSON pointer
+  const rootSchema = components ? { ...schema, components } : schema;
+
+  // Compile and validate
+  try {
+    const validate = ajv.compile(rootSchema);
+    const valid = validate(body);
+
+    if (valid) {
+      checks.push({
+        name: 'Schema validation',
+        passed: true,
+        message: 'Response body matches schema',
+      });
+    } else {
+      // Convert ajv errors to CheckResults
+      for (const error of validate.errors || []) {
+        checks.push({
+          name: 'Schema validation',
+          passed: false,
+          message: formatAjvError(error),
+          path: error.instancePath || '/',
+          expected: error.params,
+          actual: getValueAtPath(body, error.instancePath),
+        });
+      }
+    }
+  } catch (err) {
+    checks.push({
+      name: 'Schema compilation',
+      passed: false,
+      message: `Failed to compile schema: ${(err as Error).message}`,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * Validate that a status code matches expected
+ */
+export function validateStatusCode(
+  actual: number,
+  expected: number[],
+  hasDefaultResponse: boolean
+): CheckResult {
+  const passed = expected.includes(actual) || (hasDefaultResponse && !expected.includes(actual));
+
+  if (passed) {
+    return {
+      name: 'Status code',
+      passed: true,
+      message: `Received expected status ${actual}`,
+    };
+  }
+
+  return {
+    name: 'Status code',
+    passed: false,
+    message: `Unexpected status code`,
+    expected: expected.join(' or '),
+    actual,
+  };
+}
+
+/**
+ * Validate required fields are present
+ */
+export function validateRequiredFields(body: unknown, schema: SchemaSpec): CheckResult[] {
+  const checks: CheckResult[] = [];
+
+  if (typeof body !== 'object' || body === null) {
+    return checks;
+  }
+
+  const required = schema.required as string[] | undefined;
+  if (!required || !Array.isArray(required)) {
+    return checks;
+  }
+
+  const bodyObj = body as Record<string, unknown>;
+  const missingFields = required.filter((field) => !(field in bodyObj));
+
+  if (missingFields.length === 0) {
+    checks.push({
+      name: 'Required fields',
+      passed: true,
+      message: 'All required fields present',
+    });
+  } else {
+    for (const field of missingFields) {
+      checks.push({
+        name: 'Required field',
+        passed: false,
+        message: `Missing required field: ${field}`,
+        path: `/${field}`,
+        expected: 'present',
+        actual: 'missing',
+      });
+    }
+  }
+
+  return checks;
+}
+
+/**
+ * Format an ajv error into a human-readable message
+ */
+function formatAjvError(error: ErrorObject): string {
+  const path = error.instancePath || 'root';
+  const params = error.params as Record<string, unknown>;
+
+  switch (error.keyword) {
+    case 'type':
+      return `${path}: ${error.message} (expected ${params.type})`;
+    case 'required':
+      return `${path}: missing required property '${params.missingProperty}'`;
+    case 'enum':
+      return `${path}: must be one of ${JSON.stringify(params.allowedValues)}`;
+    case 'minimum':
+      return `${path}: must be >= ${params.limit}`;
+    case 'maximum':
+      return `${path}: must be <= ${params.limit}`;
+    case 'minLength':
+      return `${path}: must be at least ${params.limit} characters`;
+    case 'maxLength':
+      return `${path}: must be at most ${params.limit} characters`;
+    case 'pattern':
+      return `${path}: must match pattern ${params.pattern}`;
+    case 'format':
+      return `${path}: must be a valid ${params.format}`;
+    case 'additionalProperties':
+      return `${path}: unexpected property '${params.additionalProperty}'`;
+    default:
+      return `${path}: ${error.message || error.keyword}`;
+  }
+}
+
+/**
+ * Get a value from an object using a JSON Pointer path
+ */
+function getValueAtPath(obj: unknown, path: string): unknown {
+  if (!path || path === '/') return obj;
+
+  const parts = path.split('/').filter(Boolean);
+  let current: unknown = obj;
+
+  for (const part of parts) {
+    if (typeof current !== 'object' || current === null) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+
+  return current;
+}

--- a/packages/omg-test/tsconfig.json
+++ b/packages/omg-test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Adds the `omg test` command — contract testing that validates a **live API** against its OMG specification — and a new private `omg-test` package.

For each endpoint, `omg test`:
1. **Builds a request** — resolves path/query/header params from `--env` files, declared examples, or generated placeholders. Endpoints whose required params can't be resolved are reported as *skipped*, not failed.
2. **Sends it** to the `--against` base URL (with retries on network failure).
3. **Checks the status code** against the declared responses.
4. **Validates the response body** against the declared schema via `ajv` (JSON Schema), including `#/components/schemas` `$ref` resolution.

Supports bearer / basic / custom-header auth, endpoint filtering (`-e`), retries/timeouts, and `console` / `json` / `junit` report formats (`--report`, `-o`) for CI. Exits non-zero when any test fails.

`omg-test` is a private package bundled into `omg-md-cli` at build time, consistent with `omg-linter`, `omg-importer`, and `omg-mock-server`.

## Background

This reimplements, on current `main`, a prototype from branch `claude/omg-document-driven-dev-YdpGD` that was not mergeable: it branched before the `commands/` refactor (stale monolithic `cli.ts`), committed `dist/` artifacts, shipped no tests, and had version drift (`0.1.0` / `^0.1.0` deps against the `0.4.2` line).

## Bugs fixed while salvaging

Three genuine bugs in the prototype were found and fixed:
- **Skipped endpoints miscounted as failures** — the runner tagged them `"Skipped:"` while the summary/reporter checked `.includes('skipped')` (lowercase).
- **Response schemas with `$ref` never compiled** — `ajv` had no access to `components.schemas`. Components are now threaded through and attached to the schema root so JSON-pointer refs resolve.
- **`-e` endpoint filter mangled paths** — it uppercased the whole filter string, so `METHOD /path` matches never worked.

## Changes

- New `packages/omg-test` (private, bundled): runner, request-builder, validator, reporter, types.
- New `packages/omg-md-cli/src/commands/test.ts`, registered in `commands/index.ts` and `cli.ts`.
- Root `package.json` build order and `omg-md-cli` deps updated.
- Docs: `CHANGELOG.md`, `CLAUDE.md`, new `docusaurus/docs/cli/test.md`, updated CLI index.

## Testing

- 28 new unit tests for validator, request-builder, and reporter.
- Full suite (453 tests across all packages), `typecheck`, `build`, and `format:check` all pass.
- Smoke-tested end-to-end against `omg mock`: console/json/junit reports, auth, `-e` filter, and exit codes verified.

Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)