### PR TITLE
fix(importer): omit per-endpoint security identical to global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `omg test` command — contract testing that validates a live API against its OMG spec. For every endpoint it builds a request (resolving path/query/header parameters from `--env` files, declared examples, or generated placeholders), sends it to the `--against` base URL, and checks the response status code and body against the declared responses (JSON Schema validation via `ajv`, including `#/components/schemas` `$ref` resolution). Supports bearer / basic / custom-header auth, endpoint filtering (`-e`), retries and timeouts, and `console` / `json` / `junit` report formats (`--report`, `-o`) for CI. Exits non-zero when any test fails. Ships in the new private `omg-test` package, bundled into `omg-md-cli`. (#86)
 - `omg import` now warns when the input OpenAPI spec appears to be fully dereferenced — `components.schemas` is populated but no `$ref` is used anywhere. The warning recommends bundling the spec (e.g. `redocly bundle`, `swagger-cli bundle` without `-r`) instead of dereferencing it, since references are then preserved natively rather than recovered by structural matching. (#81)
 
+### Fixed
+
+- `omg import` no longer repeats a per-endpoint `security:` block into every endpoint when it is identical to the resolved global `security`. Per-endpoint security is emitted only when it genuinely differs from the global requirement (comparison is order-insensitive for both alternative requirements and scopes), keeping endpoint frontmatter minimal and making real overrides visible. An explicit empty `security: []` override is still preserved when it differs from a non-empty global. (#96)
+
 ## [0.4.2] - 2026-05-14
 
 ### Fixed

--- a/packages/omg-importer/src/importer.test.ts
+++ b/packages/omg-importer/src/importer.test.ts
@@ -736,4 +736,66 @@ describe('importOpenApi', () => {
       expect(paths.some((p) => p.endsWith('rule-delete.omg.md'))).toBe(true);
     });
   });
+
+  describe('per-endpoint security deduplication', () => {
+    const securedSpec = (operationSecurity?: unknown): OpenApiSpec => ({
+      ...minimalSpec,
+      security: [{ 'api-key': [], auth_token: [] }],
+      paths: {
+        '/users': {
+          get: {
+            operationId: 'list-users',
+            ...(operationSecurity !== undefined ? { security: operationSecurity } : {}),
+          } as any,
+        },
+      },
+    });
+
+    it('omits per-endpoint security identical to global security', () => {
+      const result = importOpenApi(securedSpec([{ 'api-key': [], auth_token: [] }]));
+      expect((result.endpoints[0].frontMatter as any).security).toBeUndefined();
+    });
+
+    it('omits per-endpoint security identical to global despite key/scope order', () => {
+      const result = importOpenApi(securedSpec([{ auth_token: [], 'api-key': [] }]));
+      expect((result.endpoints[0].frontMatter as any).security).toBeUndefined();
+    });
+
+    it('keeps per-endpoint security when it differs from global', () => {
+      const override = [{ 'admin-key': ['write'] }];
+      const result = importOpenApi(securedSpec(override));
+      expect((result.endpoints[0].frontMatter as any).security).toEqual(override);
+    });
+
+    it('keeps an explicit empty security override against non-empty global', () => {
+      const result = importOpenApi(securedSpec([]));
+      expect((result.endpoints[0].frontMatter as any).security).toEqual([]);
+    });
+
+    it('omits an empty security array when there is no global security', () => {
+      const spec: OpenApiSpec = {
+        ...minimalSpec,
+        paths: {
+          '/users': {
+            get: { operationId: 'list-users', security: [] } as any,
+          },
+        },
+      };
+      const result = importOpenApi(spec);
+      expect((result.endpoints[0].frontMatter as any).security).toBeUndefined();
+    });
+
+    it('keeps per-endpoint security when there is no global security', () => {
+      const spec: OpenApiSpec = {
+        ...minimalSpec,
+        paths: {
+          '/users': {
+            get: { operationId: 'list-users', security: [{ 'api-key': [] }] } as any,
+          },
+        },
+      };
+      const result = importOpenApi(spec);
+      expect((result.endpoints[0].frontMatter as any).security).toEqual([{ 'api-key': [] }]);
+    });
+  });
 });

--- a/packages/omg-importer/src/importer.ts
+++ b/packages/omg-importer/src/importer.ts
@@ -454,9 +454,18 @@ function convertOperation(
     }
   }
 
-  // Add security requirements
-  if (operation.security && operation.security.length > 0) {
-    frontMatter.security = operation.security as OmgSecurityRequirement[];
+  // Add security requirements — but only when they actually differ from the
+  // resolved global security. A spec that declares global `security` otherwise
+  // repeats an identical block into every endpoint's frontmatter; omitting it
+  // keeps endpoints minimal and makes genuine per-endpoint overrides visible.
+  // An explicit empty `security: []` (the "this endpoint needs no auth"
+  // override) is preserved whenever it differs from the global requirement.
+  if (operation.security !== undefined) {
+    const operationSecurity = operation.security as OmgSecurityRequirement[];
+    const globalSecurity = (spec.security as OmgSecurityRequirement[] | undefined) ?? [];
+    if (!securityRequirementsEqual(operationSecurity, globalSecurity)) {
+      frontMatter.security = operationSecurity;
+    }
   }
 
   // Add external docs
@@ -1095,6 +1104,35 @@ function convertSecuritySchemes(
     };
   }
   return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/**
+ * Canonicalize a security requirements array for order-insensitive comparison.
+ *
+ * OpenAPI treats the `security` array as a set of alternative requirement
+ * objects, and the scopes within each requirement as a set, so neither
+ * ordering is semantically meaningful.
+ */
+function canonicalizeSecurity(security: OmgSecurityRequirement[]): string {
+  const requirements = security.map((req) => {
+    const canonical: Record<string, string[]> = {};
+    for (const key of Object.keys(req).sort()) {
+      canonical[key] = [...(req[key] ?? [])].sort();
+    }
+    return JSON.stringify(canonical);
+  });
+  requirements.sort();
+  return JSON.stringify(requirements);
+}
+
+/**
+ * Whether two security requirement arrays express the same requirement.
+ */
+function securityRequirementsEqual(
+  a: OmgSecurityRequirement[],
+  b: OmgSecurityRequirement[]
+): boolean {
+  return canonicalizeSecurity(a) === canonicalizeSecurity(b);
 }
 
 /**


### PR DESCRIPTION
## Summary

When the source OpenAPI declares global `security`, the importer still wrote an identical `security:` block into **every** endpoint's frontmatter. On the Weavr Multi API that meant all 135 endpoints repeated the same two-line block.

This change emits per-endpoint `security` **only when it genuinely differs** from the resolved global requirement — otherwise it is omitted and the global applies. Endpoint frontmatter stays minimal and real per-endpoint overrides become visible.

## Behaviour

- Comparison is **order-insensitive** for both the list of alternative requirement objects and the scope arrays within each (OpenAPI treats both as sets).
- An explicit empty `security: []` override (the "this endpoint needs no auth" case) is now **preserved** when it differs from a non-empty global. Previously the `&& .length > 0` guard silently dropped it.
- An empty `security: []` with no global security is omitted (redundant).
- Per-endpoint security with no global security is kept.

## Tests

6 new cases in `importer.test.ts` covering identical/reordered/differing security, empty-array overrides, and the no-global cases. Full suite green (`97` importer tests).

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)