### PR TITLE
fix(importer): prune trivial type files that nothing references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `omg build` now emits binary request/response bodies under `application/octet-stream` instead of `application/json`. A body whose schema is a `string @format("binary")` is a raw file payload; serving a binary download (or accepting a binary upload) as `application/json` produced invalid OpenAPI. (#56)
 - `omg import` no longer repeats a per-endpoint `security:` block into every endpoint when it is identical to the resolved global `security`. Per-endpoint security is emitted only when it genuinely differs from the global requirement (comparison is order-insensitive for both alternative requirements and scopes), keeping endpoint frontmatter minimal and making real overrides visible. An explicit empty `security: []` override is still preserved when it differs from a non-empty global. (#96)
+- `omg import` no longer emits trivial type files that nothing references. Bare aliases (`type Iban = IBANDetails`, minted when two source schemas resolve to the same shape) and orphaned named scalars (`type UserId = string @pattern(...)`, left unreferenced when a dereferenced input inlines the equivalent constrained primitive at every call site) are now dropped. Object, array, enum, union, and intersection types are kept even when unreferenced; pruning runs to a fixpoint so alias chains collapse fully. (#93, #94)
 
 ## [0.4.2] - 2026-05-14
 

--- a/packages/omg-importer/src/importer.test.ts
+++ b/packages/omg-importer/src/importer.test.ts
@@ -907,4 +907,147 @@ describe('importOpenApi', () => {
       expect(has401).toBe(true);
     });
   });
+
+  describe('pruning trivial unreferenced types', () => {
+    const ibanShape: SchemaObject = {
+      type: 'object',
+      properties: { iban: { type: 'string' }, bic: { type: 'string' } },
+      required: ['iban'],
+    };
+
+    it('prunes an unreferenced bare type alias (#93)', () => {
+      // Two structurally identical component schemas: the importer dedups
+      // `Iban` into a `reference IBANDetails` alias. Nothing references it.
+      const spec: OpenApiSpec = {
+        ...minimalSpec,
+        components: {
+          schemas: {
+            IBANDetails: structuredClone(ibanShape),
+            Iban: structuredClone(ibanShape),
+          },
+        },
+      };
+
+      const result = importOpenApi(spec);
+
+      expect(result.types.has('Iban')).toBe(false);
+      expect(result.types.has('IBANDetails')).toBe(true);
+    });
+
+    it('keeps a bare type alias that is referenced', () => {
+      const spec: OpenApiSpec = {
+        ...minimalSpec,
+        paths: {
+          '/accounts': {
+            get: {
+              operationId: 'get-account',
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      schema: { $ref: '#/components/schemas/Iban' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            IBANDetails: structuredClone(ibanShape),
+            Iban: structuredClone(ibanShape),
+          },
+        },
+      };
+
+      const result = importOpenApi(spec);
+
+      expect(result.types.has('Iban')).toBe(true);
+    });
+
+    it('prunes an unreferenced named scalar type (#94)', () => {
+      const spec: OpenApiSpec = {
+        ...minimalSpec,
+        components: {
+          schemas: {
+            UserId: { type: 'string', pattern: '^[0-9]+$' },
+          },
+        },
+      };
+
+      const result = importOpenApi(spec);
+
+      expect(result.types.has('UserId')).toBe(false);
+    });
+
+    it('keeps a named scalar type that is referenced via $ref', () => {
+      const spec: OpenApiSpec = {
+        ...minimalSpec,
+        paths: {
+          '/users/{id}': {
+            get: {
+              operationId: 'get-user',
+              parameters: [
+                {
+                  name: 'id',
+                  in: 'path',
+                  required: true,
+                  schema: { $ref: '#/components/schemas/UserId' },
+                },
+              ],
+            },
+          },
+        },
+        components: {
+          schemas: {
+            UserId: { type: 'string', pattern: '^[0-9]+$' },
+          },
+        },
+      };
+
+      const result = importOpenApi(spec);
+
+      expect(result.types.has('UserId')).toBe(true);
+    });
+
+    it('keeps an unreferenced structural (object) type', () => {
+      const spec: OpenApiSpec = {
+        ...minimalSpec,
+        components: {
+          schemas: {
+            Widget: {
+              type: 'object',
+              properties: { id: { type: 'string' }, label: { type: 'string' } },
+            },
+          },
+        },
+      };
+
+      const result = importOpenApi(spec);
+
+      expect(result.types.has('Widget')).toBe(true);
+    });
+
+    it('prunes every alias when several schemas share one shape', () => {
+      const spec: OpenApiSpec = {
+        ...minimalSpec,
+        components: {
+          schemas: {
+            Address: structuredClone(ibanShape),
+            BillingAddress: structuredClone(ibanShape),
+            ShippingAddress: structuredClone(ibanShape),
+          },
+        },
+      };
+
+      const result = importOpenApi(spec);
+
+      // Exactly one canonical structural type survives; the aliases are gone.
+      expect(result.types.has('Address')).toBe(true);
+      expect(result.types.has('BillingAddress')).toBe(false);
+      expect(result.types.has('ShippingAddress')).toBe(false);
+    });
+  });
 });

--- a/packages/omg-importer/src/importer.ts
+++ b/packages/omg-importer/src/importer.ts
@@ -42,6 +42,7 @@ import {
   convertSchema,
   createConversionContext,
   isStructurallyNamed,
+  getReferencedSchemas,
   type ConversionContext,
 } from './schema-converter.js';
 import {
@@ -190,6 +191,10 @@ export function importOpenApi(spec: OpenApiSpec, options: ImportOptions = {}): I
       partialsMap.set(partialPath, document);
     }
   }
+
+  // Drop trivial type files (bare aliases and bare scalars) that nothing
+  // references — they only add noise to the output.
+  pruneTrivialUnreferencedTypes(types, endpoints, partialsMap);
 
   return {
     api,
@@ -901,6 +906,86 @@ function convertNamedTypes(
   }
 
   return types;
+}
+
+/**
+ * Remove trivial type files that nothing references.
+ *
+ * The importer emits a file for every `components.schemas` entry, but two
+ * kinds of those files are pure noise when unreferenced:
+ *
+ *  - bare aliases (`type Iban = IBANDetails`) — a same-shape pass-through,
+ *    typically minted when two source schemas resolved to the same shape;
+ *  - bare scalars (`type UserId = string @pattern("…")`) — when the input
+ *    was dereferenced, every call site inlines the equivalent constrained
+ *    primitive instead of referencing the named type, orphaning it.
+ *
+ * Object / array / enum / union / intersection types are never pruned even
+ * when unreferenced — they carry structure worth keeping. Pruning runs to a
+ * fixpoint so an alias chain (`A = B`, `B = string`) collapses fully.
+ */
+function pruneTrivialUnreferencedTypes(
+  types: Map<string, { schema: OmgSchema; document: OmgDocument }>,
+  endpoints: OmgDocument[],
+  partials: Map<string, OmgDocument>
+): void {
+  let pruned = true;
+  while (pruned) {
+    pruned = false;
+    const referenced = collectReferencedTypeNames(endpoints, partials, types);
+    const deletable: string[] = [];
+    for (const [name, { schema }] of types) {
+      if (!referenced.has(name) && isTrivialType(schema)) {
+        deletable.push(name);
+      }
+    }
+    for (const name of deletable) {
+      types.delete(name);
+      pruned = true;
+    }
+  }
+}
+
+/** A type is "trivial" if it is a bare reference alias or a bare scalar. */
+function isTrivialType(schema: OmgSchema): boolean {
+  return schema.kind === 'reference' || schema.kind === 'primitive';
+}
+
+/**
+ * Collect every named-type reference reachable from endpoints, partials, and
+ * the surviving type definitions themselves (a type may reference another).
+ */
+function collectReferencedTypeNames(
+  endpoints: OmgDocument[],
+  partials: Map<string, OmgDocument>,
+  types: Map<string, { schema: OmgSchema; document: OmgDocument }>
+): Set<string> {
+  const referenced = new Set<string>();
+
+  const addFrom = (schema: OmgSchema | null | undefined): void => {
+    if (!schema) return;
+    for (const name of getReferencedSchemas(schema)) {
+      referenced.add(name);
+    }
+  };
+
+  const addFromDocument = (doc: OmgDocument): void => {
+    for (const block of doc.blocks) {
+      addFrom(block.parsed);
+      const headers = block.parsedResponse?.headers;
+      if (headers) {
+        for (const header of Object.values(headers)) {
+          addFrom(header.schema);
+        }
+      }
+    }
+  };
+
+  for (const endpoint of endpoints) addFromDocument(endpoint);
+  for (const partial of partials.values()) addFromDocument(partial);
+  for (const { schema } of types.values()) addFrom(schema);
+
+  return referenced;
 }
 
 /**


### PR DESCRIPTION
## Summary

The importer emitted a type file for **every** `components.schemas` entry, including two kinds of pure noise observed when migrating the Weavr Multi API:

- **Bare aliases** (`type Iban = IBANDetails`) — minted when two source schemas resolve to the same structural shape and one dedups into a `reference` to the other. The alias is referenced nowhere.
- **Orphaned named scalars** (`type UserId = string @pattern("^[0-9]+$")`) — left unreferenced when a dereferenced input inlines the equivalent constrained primitive at every call site instead of referencing the named type.

Both are now dropped when nothing references them.

## Behaviour

- A type is pruned only if it is **unreferenced** *and* **trivial** (a bare `reference` alias or a bare `primitive`/scalar).
- Object, array, enum, union, and intersection types are **kept even when unreferenced** — they carry structure worth preserving.
- References are collected from endpoints, partials, and surviving type definitions (a type may reference another). Pruning runs to a **fixpoint** so alias chains collapse fully.
- Well-formed (bundled, `$ref`-using) inputs are unaffected: a named scalar referenced via `$ref` stays referenced and is kept.

## Tests

6 new cases in `importer.test.ts` covering pruned/kept aliases, pruned/kept named scalars, retention of unreferenced object types, and collapse of multiple aliases sharing one shape. Verified end-to-end with a build→import round-trip. Full suite green (`97` importer tests).

Fixes #93
Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)