### PR TITLE
fix(compiler): emit binary bodies as application/octet-stream + edge-case docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `omg build` now emits binary request/response bodies under `application/octet-stream` instead of `application/json`. A body whose schema is a `string @format("binary")` is a raw file payload; serving a binary download (or accepting a binary upload) as `application/json` produced invalid OpenAPI. (#56)
 - `omg import` no longer repeats a per-endpoint `security:` block into every endpoint when it is identical to the resolved global `security`. Per-endpoint security is emitted only when it genuinely differs from the global requirement (comparison is order-insensitive for both alternative requirements and scopes), keeping endpoint frontmatter minimal and making real overrides visible. An explicit empty `security: []` override is still preserved when it differs from a non-empty global. (#96)
 
 ## [0.4.2] - 2026-05-14

--- a/docusaurus/docs/edge-cases.md
+++ b/docusaurus/docs/edge-cases.md
@@ -1,0 +1,117 @@
+---
+sidebar_position: 8
+description: How OMG handles webhooks, callbacks, streaming, and binary file upload/download — what works today and what is planned.
+---
+
+# Edge cases
+
+OpenAPI supports several patterns beyond plain JSON request/response bodies.
+This page documents how OMG handles each one **today**, so you know what to
+expect when compiling to OpenAPI 3.1.
+
+| Pattern | Status |
+| --- | --- |
+| Webhooks | ✅ Supported (as relationship metadata) |
+| Binary file download | ✅ Supported |
+| Binary file upload | ✅ Supported |
+| Callbacks | 🚧 Not yet supported |
+| Streaming / server-sent events | 🚧 Not yet supported |
+| `multipart/form-data` | 🚧 Not yet supported |
+
+## Webhooks
+
+OMG models webhooks as **relationships between endpoints** rather than as a
+separate top-level construct. An endpoint declares which webhooks it triggers
+and which it listens for via the `webhooks` frontmatter key:
+
+```yaml
+---
+method: POST
+path: /companies/{companyId}/sync
+operationId: start-sync
+webhooks:
+  resulting:
+    - SyncCompleted
+    - SyncFailed
+  listen:
+    - SyncProgress
+---
+```
+
+- `webhooks.resulting` — webhooks fired as a result of calling this endpoint.
+- `webhooks.listen` — webhooks this endpoint subscribes to for progress updates.
+
+On compile these become the vendor extensions `x-webhooks-resulting` and
+`x-webhooks-listen` on the operation. The webhook *payload* itself is modelled
+as an ordinary endpoint — define the receiver as a `POST` endpoint whose
+request body is the event schema. See the `payments-api` example for a
+complete setup.
+
+> OMG does not currently emit OpenAPI 3.1's native top-level `webhooks` object.
+
+## Binary file download
+
+A response whose body is a raw file is declared as a `string` annotated with
+`@format("binary")`:
+
+```omg.response
+string @format("binary")
+```
+
+The compiler emits this under the `application/octet-stream` media type:
+
+```yaml
+responses:
+  "200":
+    description: Success
+    content:
+      application/octet-stream:
+        schema:
+          type: string
+          format: binary
+```
+
+A plain `string` body (no `@format("binary")`) stays `application/json`.
+
+> Response headers such as `Content-Disposition` cannot yet be declared in an
+> `omg.response` block.
+
+## Binary file upload
+
+The same rule applies to request bodies. An `omg.body` block whose schema is a
+binary string compiles to an `application/octet-stream` request body:
+
+```omg.body
+string @format("binary")
+```
+
+```yaml
+requestBody:
+  required: true
+  content:
+    application/octet-stream:
+      schema:
+        type: string
+        format: binary
+```
+
+This covers raw binary uploads. Multi-part uploads (a file plus metadata
+fields) are **not** yet supported — see below.
+
+## Not yet supported
+
+The following OpenAPI patterns have no OMG syntax yet. Each is tracked by its
+own issue:
+
+- **Callbacks** — OpenAPI's `callbacks` object (out-of-band requests the API
+  makes back to the caller). OMG has no syntax for it; the importer passes
+  callbacks through when reading existing specs but cannot author them.
+- **Streaming / server-sent events** — `text/event-stream` responses and
+  chunked transfer. The compiler currently emits every non-binary body as
+  `application/json`; there is no way to declare an alternative media type.
+- **`multipart/form-data`** — a request body mixing a file part with regular
+  form fields. Raw single-payload binary upload works (above), but multi-part
+  bodies need a media-type-per-field construct that OMG does not have.
+
+If you need one of these, follow or open an issue on
+[GitHub](https://github.com/mcclowes/omg/issues).

--- a/docusaurus/docs/edge-cases.md
+++ b/docusaurus/docs/edge-cases.md
@@ -103,15 +103,21 @@ fields) are **not** yet supported — see below.
 The following OpenAPI patterns have no OMG syntax yet. Each is tracked by its
 own issue:
 
-- **Callbacks** — OpenAPI's `callbacks` object (out-of-band requests the API
-  makes back to the caller). OMG has no syntax for it; the importer passes
-  callbacks through when reading existing specs but cannot author them.
-- **Streaming / server-sent events** — `text/event-stream` responses and
-  chunked transfer. The compiler currently emits every non-binary body as
-  `application/json`; there is no way to declare an alternative media type.
-- **`multipart/form-data`** — a request body mixing a file part with regular
-  form fields. Raw single-payload binary upload works (above), but multi-part
-  bodies need a media-type-per-field construct that OMG does not have.
+- **Callbacks**
+  ([#103](https://github.com/mcclowes/omg/issues/103)) — OpenAPI's `callbacks`
+  object (out-of-band requests the API makes back to the caller). OMG has no
+  syntax for it; the importer passes callbacks through when reading existing
+  specs but cannot author them.
+- **Streaming / server-sent events**
+  ([#104](https://github.com/mcclowes/omg/issues/104)) — `text/event-stream`
+  responses and chunked transfer. The compiler currently emits every
+  non-binary body as `application/json`; there is no way to declare an
+  alternative media type.
+- **`multipart/form-data`**
+  ([#105](https://github.com/mcclowes/omg/issues/105)) — a request body mixing
+  a file part with regular form fields. Raw single-payload binary upload works
+  (above), but multi-part bodies need a media-type-per-field construct that OMG
+  does not have.
 
 If you need one of these, follow or open an issue on
 [GitHub](https://github.com/mcclowes/omg/issues).

--- a/docusaurus/sidebars.ts
+++ b/docusaurus/sidebars.ts
@@ -29,6 +29,7 @@ const sidebars: SidebarsConfig = {
         'cli/change-management',
       ],
     },
+    'edge-cases',
     'examples',
   ],
 };

--- a/packages/omg-compiler/src/openapi.test.ts
+++ b/packages/omg-compiler/src/openapi.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { compileToOpenApi } from './openapi.js';
-import type { ParsedApi, OmgIntersection, OmgReference, OmgObject } from 'omg-parser';
+import type { ParsedApi, OmgIntersection, OmgReference, OmgObject, OmgPrimitive } from 'omg-parser';
 
 function createMinimalApi(types: ParsedApi['types'] = {}): ParsedApi {
   return {
@@ -178,6 +178,67 @@ describe('compileToOpenApi - intersection types', () => {
       result.paths['/test']?.get?.responses?.['200']?.content?.['application/json']?.schema;
     expect(responseSchema?.allOf).toBeDefined();
     expect(responseSchema?.allOf).toHaveLength(2);
+  });
+});
+
+describe('compileToOpenApi - binary body media types', () => {
+  const binaryString: OmgPrimitive = {
+    kind: 'primitive',
+    type: 'string',
+    annotations: [{ name: 'format', args: ['binary'] }],
+  };
+
+  const endpointApi = (overrides: Partial<ParsedApi['endpoints'][number]>): ParsedApi => ({
+    ...createMinimalApi(),
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/file',
+        operationId: 'get-file',
+        tags: [],
+        summary: 'Get file',
+        description: '',
+        deprecated: false,
+        follows: [],
+        webhooks: {},
+        parameters: { path: null, query: null, headers: null },
+        requestBody: null,
+        responses: {},
+        ...overrides,
+      },
+    ],
+  });
+
+  it('emits a binary response under application/octet-stream', () => {
+    const api = endpointApi({ responses: { 200: { schema: binaryString } } });
+    const result = compileToOpenApi(api);
+
+    const content = result.paths['/file']?.get?.responses?.['200']?.content;
+    expect(content?.['application/octet-stream']).toBeDefined();
+    expect(content?.['application/json']).toBeUndefined();
+  });
+
+  it('emits a binary request body under application/octet-stream', () => {
+    const api = endpointApi({ method: 'POST', requestBody: binaryString });
+    const result = compileToOpenApi(api);
+
+    const content = result.paths['/file']?.post?.requestBody?.content;
+    expect(content?.['application/octet-stream']).toBeDefined();
+    expect(content?.['application/json']).toBeUndefined();
+  });
+
+  it('keeps a regular object response under application/json', () => {
+    const objectSchema: OmgObject = {
+      kind: 'object',
+      properties: { id: { kind: 'primitive', type: 'string', annotations: [] } },
+      annotations: [],
+    };
+    const api = endpointApi({ responses: { 200: { schema: objectSchema } } });
+    const result = compileToOpenApi(api);
+
+    const content = result.paths['/file']?.get?.responses?.['200']?.content;
+    expect(content?.['application/json']).toBeDefined();
+    expect(content?.['application/octet-stream']).toBeUndefined();
   });
 });
 

--- a/packages/omg-compiler/src/openapi.ts
+++ b/packages/omg-compiler/src/openapi.ts
@@ -466,7 +466,7 @@ function compileEndpointWithContext(
     operation.requestBody = {
       required: true,
       content: {
-        'application/json': {
+        [mediaTypeForBody(endpoint.requestBody)]: {
           schema: compileSchemaWithContext(endpoint.requestBody, ctx),
         },
       },
@@ -504,7 +504,7 @@ function compileEndpointWithContext(
         mediaType.examples = response.examples as Record<string, ExampleObject>;
       }
 
-      oasResponse.content = { 'application/json': mediaType };
+      oasResponse.content = { [mediaTypeForBody(response.schema)]: mediaType };
     }
 
     // Add response headers
@@ -893,6 +893,26 @@ function applyAnnotations(schema: SchemaObject, annotations: OmgAnnotation[]): v
         break;
     }
   }
+}
+
+/**
+ * Choose the OpenAPI media type for a request or response body.
+ *
+ * A bare binary string (`string @format("binary")`) is a raw file payload, so
+ * it is emitted under `application/octet-stream` — serving a binary download
+ * or accepting a binary upload as `application/json` produces invalid
+ * OpenAPI. Every other body stays `application/json`.
+ */
+function mediaTypeForBody(schema: OmgType | null | undefined): string {
+  if (
+    schema &&
+    schema.kind === 'primitive' &&
+    schema.type === 'string' &&
+    schema.annotations.some((a) => a.name === 'format' && a.args[0] === 'binary')
+  ) {
+    return 'application/octet-stream';
+  }
+  return 'application/json';
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses #56 (document edge cases). The investigation found one concrete correctness bug plus a documentation gap.

### Bug fix: binary bodies compiled to `application/json`

A request/response body whose schema is `string @format("binary")` is a raw file payload. The compiler hardcoded `application/json` for **every** body, so binary downloads compiled to invalid OpenAPI:

```yaml
# before — a PDF served as JSON
content:
  application/json:
    schema: { type: string, format: binary }
```

The Xero example's 25+ PDF-download endpoints were all affected. `mediaTypeForBody` now selects `application/octet-stream` for a binary string body (request or response); every other body stays `application/json`. Verified by recompiling the Xero example.

### Docs: `docusaurus/docs/edge-cases.md`

A new page honestly documenting how OMG handles each OpenAPI edge case **today**:

| Pattern | Status |
| --- | --- |
| Webhooks | ✅ Supported (relationship metadata → `x-webhooks-*`) |
| Binary download / upload | ✅ Supported (`application/octet-stream`) |
| Callbacks | 🚧 Not yet supported |
| Streaming / SSE | 🚧 Not yet supported |
| `multipart/form-data` | 🚧 Not yet supported |

## Follow-ups

The three unsupported patterns each need new OMG syntax (a media-type construct / a callbacks frontmatter key) — too large for this PR. I will open separate tracking issues for callbacks, streaming, and `multipart/form-data` so #56 can close on the documentation + bug-fix deliverable.

## Tests

3 new compiler tests (binary response, binary request, regular JSON response unaffected). All 9 compiler tests pass.

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)