### PR TITLE
feat(mock): @vague annotation overrides mock-data generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `omg test` command — contract testing that validates a live API against its OMG spec. For every endpoint it builds a request (resolving path/query/header parameters from `--env` files, declared examples, or generated placeholders), sends it to the `--against` base URL, and checks the response status code and body against the declared responses (JSON Schema validation via `ajv`, including `#/components/schemas` `$ref` resolution). Supports bearer / basic / custom-header auth, endpoint filtering (`-e`), retries and timeouts, and `console` / `json` / `junit` report formats (`--report`, `-o`) for CI. Exits non-zero when any test fails. Ships in the new private `omg-test` package, bundled into `omg-md-cli`. (#86)
 - `omg import` now warns when the input OpenAPI spec appears to be fully dereferenced — `components.schemas` is populated but no `$ref` is used anywhere. The warning recommends bundling the spec (e.g. `redocly bundle`, `swagger-cli bundle` without `-r`) instead of dereferencing it, since references are then preserved natively rather than recovered by structural matching. (#81)
+- `@vague("...")` annotation — controls how `omg mock` generates a field's value. The argument is a Vague expression used verbatim, overriding the mock server's field-name heuristics and constraint inference (e.g. `status: string @vague("0.7: \"paid\" | 0.3: \"overdue\"")`). It affects mock generation only and never appears in compiled OpenAPI output. (#57)
 
 ### Fixed
 

--- a/docusaurus/docs/syntax/annotations.md
+++ b/docusaurus/docs/syntax/annotations.md
@@ -53,6 +53,40 @@ Annotations add constraints and metadata to fields using the `@` prefix.
 | `@minItems(n)` | Minimum array length |
 | `@maxItems(n)` | Maximum array length |
 
+## Mock data: `@vague`
+
+The `@vague("...")` annotation controls how the mock server
+([`omg mock`](../cli/index.md)) generates a value for a field. Its argument is
+a Vague type expression that is used **verbatim** — it overrides the
+field-name heuristics and constraint inference the mock server applies by
+default.
+
+```
+{
+  status: string @vague("0.7: \"paid\" | 0.2: \"sent\" | 0.1: \"overdue\""),
+  amount: decimal @vague("decimal in 100..10000"),
+  score: integer @vague("int in 0..100")
+}
+```
+
+| Annotation | Description |
+|------------|-------------|
+| `@vague("expr")` | Vague expression used verbatim by the mock server |
+
+Notes:
+
+- `@vague` affects **mock generation only**. It is ignored by `omg build` — it
+  never appears in the compiled OpenAPI output.
+- Without `@vague`, the mock server still generates realistic data from the
+  field name, `@format`, and numeric/length constraints. Use `@vague` only when
+  you need to override that — e.g. a weighted distribution of statuses or a
+  value within a specific range.
+- A declared example (an `omg.example` block, or an `example` / `examples`
+  value on the schema) takes precedence over generated data: `@vague` drives
+  the values for fields that have **no** explicit example.
+- Escape the inner `"` quotes with `\"`, since the expression is itself a
+  quoted string argument.
+
 ## Default values
 
 Use `= value` syntax for defaults:

--- a/packages/omg-mock-server/src/vague-generator.ts
+++ b/packages/omg-mock-server/src/vague-generator.ts
@@ -184,6 +184,14 @@ function typeToVague(
   typeDefs: string[],
   fieldName: string = 'field'
 ): string {
+  // An explicit `@vague("<expr>")` annotation is the author's override: its
+  // argument is used verbatim as the Vague type expression for this field,
+  // bypassing the field-name heuristics and constraint inference below.
+  const vagueOverride = getVagueExpression(schema.annotations);
+  if (vagueOverride !== undefined) {
+    return vagueOverride;
+  }
+
   const constraints = parseAnnotations(schema.annotations);
 
   switch (schema.kind) {
@@ -319,6 +327,25 @@ interface ParsedConstraints {
   maxItems?: number;
   pattern?: string;
   format?: string;
+}
+
+/**
+ * Extract the expression from a `@vague("<expr>")` annotation, if present.
+ *
+ * The argument is a raw Vague type expression — e.g.
+ * `@vague("0.7: \"paid\" | 0.3: \"overdue\"")` or
+ * `@vague("decimal in 100..10000")` — and is substituted directly into the
+ * generated Vague schema. Returns `undefined` when the field has no `@vague`
+ * annotation, or when the annotation has no (or an empty) argument.
+ */
+function getVagueExpression(annotations: OmgAnnotation[]): string | undefined {
+  for (const ann of annotations) {
+    if (ann.name === 'vague' && ann.args.length > 0) {
+      const expr = String(ann.args[0]).trim();
+      if (expr.length > 0) return expr;
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/packages/omg-mock-server/test/vague-generator.test.ts
+++ b/packages/omg-mock-server/test/vague-generator.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Vague Generator Tests
+ *
+ * Covers the `@vague(...)` annotation override.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateWithVague } from '../src/vague-generator.js';
+import type { OmgSchema } from 'omg-parser';
+
+/** Build a single-field object schema for `field`. */
+function objectWith(field: OmgSchema): OmgSchema {
+  return {
+    kind: 'object',
+    properties: { field },
+    annotations: [],
+  };
+}
+
+describe('vague-generator @vague annotation', () => {
+  it('uses an @vague integer expression verbatim', async () => {
+    const schema = objectWith({
+      kind: 'primitive',
+      type: 'integer',
+      annotations: [{ name: 'vague', args: ['int in 7..7'] }],
+    });
+
+    const result = (await generateWithVague(schema, { seed: 1 })) as Record<string, unknown>;
+
+    expect(result.field).toBe(7);
+  });
+
+  it('uses an @vague string-literal expression verbatim', async () => {
+    const schema = objectWith({
+      kind: 'primitive',
+      type: 'string',
+      annotations: [{ name: 'vague', args: ['"ACTIVE"'] }],
+    });
+
+    const result = (await generateWithVague(schema, { seed: 1 })) as Record<string, unknown>;
+
+    expect(result.field).toBe('ACTIVE');
+  });
+
+  it('overrides the field-name heuristic when @vague is present', async () => {
+    // A field named `email` would normally generate via the `email()` faker;
+    // the @vague annotation must win.
+    const schema: OmgSchema = {
+      kind: 'object',
+      properties: {
+        email: {
+          kind: 'primitive',
+          type: 'string',
+          annotations: [{ name: 'vague', args: ['"noreply@example.test"'] }],
+        },
+      },
+      annotations: [],
+    };
+
+    const result = (await generateWithVague(schema, { seed: 1 })) as Record<string, unknown>;
+
+    expect(result.email).toBe('noreply@example.test');
+  });
+
+  it('falls back to heuristics when no @vague annotation is present', async () => {
+    const schema: OmgSchema = {
+      kind: 'object',
+      properties: {
+        email: { kind: 'primitive', type: 'string', annotations: [] },
+      },
+      annotations: [],
+    };
+
+    const result = (await generateWithVague(schema, { seed: 1 })) as Record<string, unknown>;
+
+    // The `email` field-name heuristic produces a real-looking email address.
+    expect(typeof result.email).toBe('string');
+    expect(result.email).toMatch(/@/);
+  });
+
+  it('honours a weighted-union @vague expression', async () => {
+    const schema = objectWith({
+      kind: 'primitive',
+      type: 'string',
+      annotations: [{ name: 'vague', args: ['0.5: "paid" | 0.5: "overdue"'] }],
+    });
+
+    const result = (await generateWithVague(schema, { seed: 3 })) as Record<string, unknown>;
+
+    expect(['paid', 'overdue']).toContain(result.field);
+  });
+});


### PR DESCRIPTION
## Summary

Finalizes the Vague integration syntax (#57). The mock server (`omg mock`) already generates realistic data via field-name heuristics + constraint annotations, but there was **no way to override** generation per field.

A **`@vague("<expr>")`** annotation now supplies a [Vague](https://github.com/mcclowes/vague) type expression used **verbatim** for that field, taking precedence over the heuristics:

```
{
  status: string @vague("0.7: \"paid\" | 0.2: \"sent\" | 0.1: \"overdue\""),
  amount: decimal @vague("decimal in 100..10000"),
  score:  integer @vague("int in 0..100")
}
```

## Design decisions (the open questions from #57)

- **How `@vague` attaches to fields** — as a standard field annotation. The parser already accepts arbitrary `@name(args)` annotations, so no parser change was needed; the annotation is consumed at the mock server's Vague-conversion step (`typeToVague`).
- **`@vague` vs. heuristics** — `@vague` always wins. Without it, the existing field-name / `@format` / constraint inference still applies.
- **`@vague` vs. named examples** — a declared example (`omg.example` block or `example` / `examples` on a schema) takes precedence over generated data; `@vague` drives values for fields with no explicit example. Documented in `annotations.md`.
- **`@vague` and compilation** — it affects mock generation only. The OMG compiler ignores unknown annotations, so `@vague` never reaches the compiled OpenAPI.

## Tests & docs

- 5 new tests in `vague-generator.test.ts` (integer range, string literal, heuristic override, heuristic fallback, weighted union).
- New "Mock data: `@vague`" section in `docusaurus/docs/syntax/annotations.md`.

Fixes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)