### PR TITLE
chore: add monthly batched Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot — monthly batched version updates + grouped security updates.
+# https://docs.github.com/code-security/dependabot
+version: 2
+updates:
+  - package-ecosystem: npm
+    directories:
+      - '/' # npm workspace root (covers packages/*)
+      - '/docusaurus'
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      # One PR/month for all minor + patch version bumps. Majors stay
+      # separate so breaking changes are reviewed individually.
+      npm-version-updates:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      # Batch security fixes too, so CVE bumps don't trickle in one-per-PR.
+      npm-security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
This repo had no Dependabot config, so security-update PRs were trickling in one per advisory. Adds a config to batch them.

- Monthly schedule for version updates
- **Version updates:** minor + patch bumps grouped into one PR/month; majors open individually
- **Security updates:** CVE bumps grouped into one PR instead of one-per-advisory
- Covers `/` (npm workspace root) and `/docusaurus`

🤖 Generated with [Claude Code](https://claude.com/claude-code)