### PR TITLE
Improve GitHub rendered-UI experience for OMG files

### DIFF
--- a/.claude/skills/omg/SKILL.md
+++ b/.claude/skills/omg/SKILL.md
@@ -32,7 +32,7 @@ Returns details of a specific account.
 - **Code blocks**: `omg.path`, `omg.query`, `omg.body`, `omg.response`, `omg.response.{code}`, `omg.returns`, `omg.type`
 - **Types**: `string`, `integer`, `decimal`, `boolean`, `date`, `datetime`, `uuid`, `any`
 - **Syntax**: `field?: type` (optional), `type[]` (array), `"a"|"b"` (enum), `@min(0)` (constraints)
-- **Partials**: `@path/to/partial` or `{{> path/to/partial }}` for reuse
+- **Partials**: `@path/to/partial`, `{{> path/to/partial }}`, or a Markdown link to a `.omg.md` file (`[label](../partials/x.omg.md)`, resolved relative to the document and clickable in GitHub) for reuse
 
 ## CLI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Markdown-link partial includes — a partial can now be referenced with a plain Markdown link whose destination ends in `.omg.md` (e.g. `[idempotency-ref](../partials/headers/idempotency-ref.omg.md)`), in addition to the existing `@name` and `{{> name }}` forms. Unlike the logical-name forms (resolved under `partials/`), a link partial is resolved relative to the referencing document, so the same reference also renders as a **clickable link** in GitHub's rendered Markdown view instead of showing literal `{{> ... }}` / `@...` text. (#121)
+
+### Changed
+
+- `omg fmt` now inserts a `// no response body` comment into empty response blocks (`omg.response`, `omg.response.{code}`, `omg.response.default`). A bodyless response otherwise renders as an empty grey box in GitHub's rendered Markdown view, which reads as a mistake; the comment makes the intent explicit. Compiled output is unchanged (an empty body and a comment-only body both mean no response schema), and formatting is idempotent. (#122)
+
 ## [0.5.0] - 2026-05-22
 
 ### Added

--- a/docusaurus/docs/syntax/partials.md
+++ b/docusaurus/docs/syntax/partials.md
@@ -29,6 +29,24 @@ The `\{\{> path \}\}` syntax is also supported:
 
 Both syntaxes are equivalent and can be mixed in the same document.
 
+### Markdown-link style
+
+You can also include a partial with a plain Markdown link, as long as the
+destination ends in `.omg.md`:
+
+```markdown
+[idempotency-ref](../partials/headers/idempotency-ref.omg.md)
+```
+
+This form has one advantage the others don't: it renders as a **clickable link**
+in GitHub's rendered Markdown view, instead of showing literal `{{> ... }}` or
+`@...` text. Use it when readers browse your specs on GitHub.
+
+Unlike the `@name` / `{{> name }}` forms — which look up a logical name under
+`partials/` — a Markdown-link partial is resolved **relative to the document**
+that references it (standard Markdown link semantics), so the same path also
+works as a clickable link.
+
 ## Basic usage
 
 Include a partial at the end of your endpoint definition:

--- a/grammar/omg.peg
+++ b/grammar/omg.peg
@@ -77,15 +77,19 @@ DocElement
 Heading
   = "#"+ " " RawLine
 
-// A line that contains only a partial reference. Two interchangeable syntaxes:
-//   {{> path/to/partial }}   (Handlebars style)
-//   @path/to/partial         (OMG style — recommended)
+// A line that contains only a partial reference. Three interchangeable syntaxes:
+//   {{> path/to/partial }}                (Handlebars style)
+//   @path/to/partial                      (OMG style — recommended)
+//   [label](path/to/partial.omg.md)       (Markdown link — clickable in GitHub)
+// The @/{{>}} forms resolve a logical name under partials/; the Markdown-link
+// form resolves its destination relative to the referencing document.
 PartialLine
   = InlineSpace* PartialRef InlineSpace* LineEnd
 
 PartialRef
   = HandlebarsPartial
   / AtPartial
+  / LinkPartial
 
 HandlebarsPartial
   = "{{>" InlineSpace* PartialPath InlineSpace* "}}"
@@ -93,8 +97,15 @@ HandlebarsPartial
 AtPartial
   = "@" PartialPath
 
+LinkPartial
+  = "[" [^\]]* "]" "(" InlineSpace* LinkPartialPath InlineSpace* ")"
+
 PartialPath
   = [a-zA-Z] [a-zA-Z0-9_/-]*
+
+// A Markdown-link partial destination: any path ending in .omg or .omg.md
+LinkPartialPath
+  = [^)\t ]+ ".omg" ".md"?
 
 // A blank or whitespace-only line. Consumes the newline, so it is non-empty.
 BlankLine

--- a/packages/omg-importer/src/importer.ts
+++ b/packages/omg-importer/src/importer.ts
@@ -579,7 +579,7 @@ function convertOperation(
       if (partialPath) {
         // Avoid duplicate partial references
         if (!partialRefs.some((p) => p.path === partialPath)) {
-          partialRefs.push({ path: partialPath, line: 0 });
+          partialRefs.push({ path: partialPath, line: 0, kind: 'logical' });
         }
       }
     }

--- a/packages/omg-importer/src/response-extractor.ts
+++ b/packages/omg-importer/src/response-extractor.ts
@@ -96,7 +96,7 @@ export function extractRepeatedResponses(
       if (!isResponseBlock(block)) return true;
       const partialPath = fingerprintToPath.get(responseFingerprint(block));
       if (!partialPath) return true;
-      newRefs.push({ path: partialPath, line: 0 });
+      newRefs.push({ path: partialPath, line: 0, kind: 'logical' });
       return false;
     });
     newRefs.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));

--- a/packages/omg-parser/src/document-parser.test.ts
+++ b/packages/omg-parser/src/document-parser.test.ts
@@ -834,6 +834,93 @@ path: /test
       // The @format annotation should NOT be parsed as a partial
       expect(doc.partials).toHaveLength(0);
     });
+
+    it('parses markdown-link partials pointing at .omg.md files', () => {
+      const content = `---
+method: GET
+path: /test
+---
+
+# Test
+
+[idempotency-ref](../../partials/headers/idempotency-ref.omg.md)
+`;
+
+      const doc = parseDocument(content, 'test.omg.md');
+
+      expect(doc.partials).toHaveLength(1);
+      expect(doc.partials[0].path).toBe('../../partials/headers/idempotency-ref.omg.md');
+      expect(doc.partials[0].kind).toBe('path');
+    });
+
+    it('tags {{>}} and @ partials as logical', () => {
+      const content = `---
+method: GET
+path: /test
+---
+
+# Test
+
+{{> params/company }}
+@responses/errors
+`;
+
+      const doc = parseDocument(content, 'test.omg.md');
+
+      expect(doc.partials.every((p) => p.kind === 'logical')).toBe(true);
+    });
+
+    it('ignores ordinary markdown links that are not .omg.md', () => {
+      const content = `---
+method: GET
+path: /test
+---
+
+# Test
+
+See the [docs](https://example.com/docs) and the [readme](../README.md).
+`;
+
+      const doc = parseDocument(content, 'test.omg.md');
+
+      expect(doc.partials).toHaveLength(0);
+    });
+
+    it('does not treat .omg.md links inside code blocks as partials', () => {
+      const content = `---
+method: GET
+path: /test
+---
+
+# Test
+
+\`\`\`omg.example
+{ "link": "[x](foo.omg.md)" }
+\`\`\`
+`;
+
+      const doc = parseDocument(content, 'test.omg.md');
+
+      expect(doc.partials).toHaveLength(0);
+    });
+
+    it('excludes markdown-link partials from the description', () => {
+      const content = `---
+method: GET
+path: /test
+---
+
+# Test
+
+A real description.
+
+[idempotency-ref](../partials/headers/idempotency-ref.omg.md)
+`;
+
+      const doc = parseDocument(content, 'test.omg.md');
+
+      expect(doc.description).toBe('A real description.');
+    });
   });
 
   describe('file path handling', () => {

--- a/packages/omg-parser/src/document-parser.ts
+++ b/packages/omg-parser/src/document-parser.ts
@@ -37,6 +37,10 @@ const WHEN_PATTERN = /@when\((\w+)\s*=\s*"([^"]+)"\)/;
 // - OMG style: @path/to/partial
 const PARTIAL_PATTERN = /\{\{>\s*([^}\s]+)\s*\}\}/g;
 const AT_PARTIAL_PATTERN = /(?:^|\s)@([a-zA-Z][a-zA-Z0-9_/-]*)(?:\s|$)/g;
+// Markdown-link partials: [label](path/to/partial.omg.md) — renders as a
+// clickable link in GitHub's UI and resolves as an include. The destination
+// must end in `.omg.md` (or `.omg`) to be treated as a partial.
+const LINK_PARTIAL_PATTERN = /\[[^\]]*\]\(\s*([^)\s]+\.omg(?:\.md)?)\s*\)/g;
 
 /**
  * Parse a .omg.md file into an OmgDocument
@@ -101,13 +105,18 @@ function extractDescription(tree: Root, rawContent: string): string {
       continue;
     }
 
-    // Skip partial references ({{> ... }} or @path)
+    // Skip partial references ({{> ... }}, @path, or [label](x.omg.md))
     if (node.type === 'paragraph') {
       const text = extractTextFromNode(node);
       // Reset lastIndex for global regex patterns
       PARTIAL_PATTERN.lastIndex = 0;
       AT_PARTIAL_PATTERN.lastIndex = 0;
       if (PARTIAL_PATTERN.test(text) || AT_PARTIAL_PATTERN.test(text)) {
+        continue;
+      }
+      // Link-partials show up as mdast link nodes; their destination (not the
+      // visible label) carries the `.omg.md` marker.
+      if (paragraphHasLinkPartial(node)) {
         continue;
       }
     }
@@ -121,6 +130,20 @@ function extractDescription(tree: Root, rawContent: string): string {
   }
 
   return descriptionParts.join('\n\n').trim();
+}
+
+/**
+ * Whether a paragraph node contains a markdown-link partial — a link whose
+ * destination ends in `.omg.md` (or `.omg`).
+ */
+function paragraphHasLinkPartial(node: any): boolean {
+  if (node.type === 'link' && typeof node.url === 'string' && /\.omg(\.md)?$/.test(node.url)) {
+    return true;
+  }
+  if (node.children) {
+    return node.children.some(paragraphHasLinkPartial);
+  }
+  return false;
 }
 
 /**
@@ -291,7 +314,19 @@ function extractPartials(content: string): PartialRef[] {
   const partials: PartialRef[] = [];
   const lines = content.split('\n');
 
+  // Track fenced code blocks so references inside them (e.g. a `.omg.md` link
+  // in a JSON example) are not mistaken for partials.
+  let inFence = false;
+
   lines.forEach((line, index) => {
+    if (/^```/.test(line.trim())) {
+      inFence = !inFence;
+      return;
+    }
+    if (inFence) {
+      return;
+    }
+
     let match;
 
     // Check Handlebars-style partials: {{> path }}
@@ -300,6 +335,7 @@ function extractPartials(content: string): PartialRef[] {
       partials.push({
         path: match[1],
         line: index + 1,
+        kind: 'logical',
       });
     }
 
@@ -309,6 +345,17 @@ function extractPartials(content: string): PartialRef[] {
       partials.push({
         path: match[1],
         line: index + 1,
+        kind: 'logical',
+      });
+    }
+
+    // Check markdown-link partials: [label](path.omg.md)
+    LINK_PARTIAL_PATTERN.lastIndex = 0;
+    while ((match = LINK_PARTIAL_PATTERN.exec(line)) !== null) {
+      partials.push({
+        path: match[1],
+        line: index + 1,
+        kind: 'path',
       });
     }
   });

--- a/packages/omg-parser/src/formatter.test.ts
+++ b/packages/omg-parser/src/formatter.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { formatDocument } from './formatter.js';
+
+describe('formatDocument', () => {
+  describe('empty response blocks', () => {
+    it('inserts "// no response body" into an empty response block', () => {
+      const input = ['```omg.response.401', '', '```', ''].join('\n');
+      const formatted = formatDocument(input);
+      expect(formatted).toContain('```omg.response.401\n// no response body\n```');
+    });
+
+    it('handles a block whose body is only whitespace', () => {
+      const input = ['```omg.response.204', '   ', '```', ''].join('\n');
+      const formatted = formatDocument(input);
+      expect(formatted).toContain('```omg.response.204\n// no response body\n```');
+    });
+
+    it('applies to the default response block', () => {
+      const input = ['```omg.response.default', '', '```', ''].join('\n');
+      const formatted = formatDocument(input);
+      expect(formatted).toContain('```omg.response.default\n// no response body\n```');
+    });
+
+    it('is idempotent — a comment-only block is left unchanged', () => {
+      const input = ['```omg.response.401', '// no response body', '```', ''].join('\n');
+      const formatted = formatDocument(input);
+      expect(formatted).toContain('```omg.response.401\n// no response body\n```');
+      // Formatting again is stable
+      expect(formatDocument(formatted)).toBe(formatted);
+    });
+
+    it('does not touch response blocks that have a body', () => {
+      const input = ['```omg.response.200', '{ id: string }', '```', ''].join('\n');
+      const formatted = formatDocument(input);
+      expect(formatted).not.toContain('// no response body');
+      expect(formatted).toContain('id: string');
+    });
+
+    it('does not add the comment to non-response empty blocks', () => {
+      const input = ['```omg.path', '', '```', ''].join('\n');
+      const formatted = formatDocument(input);
+      expect(formatted).not.toContain('// no response body');
+    });
+  });
+});

--- a/packages/omg-parser/src/formatter.ts
+++ b/packages/omg-parser/src/formatter.ts
@@ -163,6 +163,18 @@ function formatBody(body: string, indent: number): string {
 
     // Check for code block end
     if (line.trim() === '```' && inCodeBlock) {
+      // An empty response block declares a bodyless (e.g. 204-style) response.
+      // Emit a `// no response body` comment so it doesn't render as an empty
+      // grey box in GitHub's rendered markdown view, which reads as a mistake.
+      if (isResponseBlock(codeBlockType) && codeBlockContent.join('\n').trim() === '') {
+        result.push('// no response body');
+        result.push('```');
+        inCodeBlock = false;
+        codeBlockType = '';
+        codeBlockContent = [];
+        continue;
+      }
+
       // Format the code block content if it's an OMG block
       if (isOmgSchemaBlock(codeBlockType)) {
         const formatted = formatOmgSchema(codeBlockContent.join('\n'), indent);
@@ -198,6 +210,14 @@ function formatBody(body: string, indent: number): string {
  */
 function isOmgSchemaBlock(type: string): boolean {
   return type.startsWith('omg.') && type !== 'omg.example' && type !== 'omg.config';
+}
+
+/**
+ * Check if a code block type is a response block
+ * (omg.response, omg.response.{code}, omg.response.default)
+ */
+function isResponseBlock(type: string): boolean {
+  return type === 'omg.response' || type.startsWith('omg.response.');
 }
 
 /**

--- a/packages/omg-parser/src/resolver.test.ts
+++ b/packages/omg-parser/src/resolver.test.ts
@@ -75,6 +75,66 @@ path: /users
       expect(resolved.resolvedBlocks.length).toBeGreaterThan(0);
     });
 
+    it('resolves markdown-link partials relative to the document directory', () => {
+      const mainContent = `---
+method: GET
+path: /users
+---
+
+# Get Users
+
+[errors](../partials/responses/errors.omg.md)
+`;
+
+      const partialContent = `# Standard Errors
+
+\`\`\`omg.response.400
+{
+  error: string
+}
+\`\`\`
+`;
+
+      const resolvedPartialPath = path.resolve(
+        '/project/endpoints',
+        '../partials/responses/errors.omg.md'
+      );
+
+      vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+        return p.toString() === resolvedPartialPath;
+      });
+      vi.mocked(fs.readFileSync).mockImplementation((p: fs.PathOrFileDescriptor) => {
+        return p.toString() === resolvedPartialPath ? partialContent : '';
+      });
+
+      const doc = parseDocument(mainContent, 'endpoints/users.omg.md');
+      const resolved = resolveDocument(doc, { basePath: '/project', noCache: true });
+
+      expect(
+        resolved.resolvedBlocks.some((b) => b.type === 'omg.response' && b.statusCode === 400)
+      ).toBe(true);
+    });
+
+    it('throws a path-aware error for a missing markdown-link partial', () => {
+      const content = `---
+method: GET
+path: /test
+---
+
+# Test
+
+[missing](./partials/missing.omg.md)
+`;
+
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const doc = parseDocument(content, 'test.omg.md');
+
+      expect(() => resolveDocument(doc, { basePath: '/project', noCache: true })).toThrow(
+        /Partial not found/
+      );
+    });
+
     it('throws error for missing partial', () => {
       const content = `---
 method: GET

--- a/packages/omg-parser/src/resolver.ts
+++ b/packages/omg-parser/src/resolver.ts
@@ -221,18 +221,30 @@ export function resolveDocument(
 
   // Resolve each partial
   for (const partial of doc.partials) {
-    const partialPath = resolvePartialPath(partial.path, options.basePath);
+    // `path` partials are markdown links resolved relative to the referencing
+    // document; `logical` partials are names resolved via the partials/ dir.
+    const partialPath =
+      partial.kind === 'path'
+        ? path.resolve(path.dirname(docPath), partial.path)
+        : resolvePartialPath(partial.path, options.basePath);
 
     if (!fs.existsSync(partialPath)) {
-      throw new Error(
-        `Partial not found: '${partial.path}' at line ${partial.line}.\n` +
-          `Searched: ${partialPath}\n` +
-          `Make sure the file exists in your partials/ directory.\n` +
-          `Expected: partials/${partial.path}.omg.md`
-      );
+      const hint =
+        partial.kind === 'path'
+          ? `Searched: ${partialPath}\n` +
+            `The link destination is resolved relative to the referencing document.`
+          : `Searched: ${partialPath}\n` +
+            `Make sure the file exists in your partials/ directory.\n` +
+            `Expected: partials/${partial.path}.omg.md`;
+      throw new Error(`Partial not found: '${partial.path}' at line ${partial.line}.\n` + hint);
     }
 
     const partialContent = fs.readFileSync(partialPath, 'utf-8');
+
+    // The nested document's filePath must let resolveDocument recompute the
+    // same absolute path, so its own relative links resolve correctly.
+    const nestedFilePath =
+      partial.kind === 'path' ? path.relative(options.basePath, partialPath) : partial.path;
 
     // Try to get cached document, or parse and cache it
     let partialDoc: OmgDocument;
@@ -241,11 +253,11 @@ export function resolveDocument(
       if (cached) {
         partialDoc = cached;
       } else {
-        partialDoc = parseDocument(partialContent, partial.path);
+        partialDoc = parseDocument(partialContent, nestedFilePath);
         documentCache.set(partialPath, partialContent, partialDoc);
       }
     } else {
-      partialDoc = parseDocument(partialContent, partial.path);
+      partialDoc = parseDocument(partialContent, nestedFilePath);
     }
 
     // Recursively resolve the partial

--- a/packages/omg-parser/src/types.ts
+++ b/packages/omg-parser/src/types.ts
@@ -230,8 +230,21 @@ export interface ParsedReturnsBlock {
 
 // Partial reference
 export interface PartialRef {
+  /**
+   * The partial reference. For `logical` partials this is a logical name
+   * resolved via the `partials/` directory (e.g. `headers/idempotency-ref`).
+   * For `path` partials this is a markdown-link destination resolved relative
+   * to the referencing document (e.g. `../partials/headers/x.omg.md`).
+   */
   path: string;
   line: number;
+  /**
+   * How the reference was written:
+   * - `logical` — `{{> name }}` or `@name`, resolved via the partials/ dir
+   * - `path` — a markdown link `[label](dest.omg.md)`, resolved relative to
+   *   the document so the link is also clickable in GitHub's rendered view
+   */
+  kind: 'logical' | 'path';
 }
 
 // Parsed document


### PR DESCRIPTION
## Why

When `.omg.md` files are viewed in GitHub's *rendered* Markdown view (not raw), two things read as mistakes to a casual browser:

1. Partial includes render as literal `{{> headers/idempotency-ref }}` / `@headers/idempotency-ref` text — looks like leftover Handlebars that failed to compile.
2. Bodyless response blocks render as an empty grey box — reads as a broken/empty block.

This PR addresses both. GitHub gives no CSS/JS hooks, so the fix is to choose markup that already degrades well.

## What

### Markdown-link partials (Closes #121)

A partial can now be referenced with a plain Markdown link whose destination ends in `.omg.md`:

```markdown
[idempotency-ref](../partials/headers/idempotency-ref.omg.md)
```

- Renders as a **clickable link** to the partial on GitHub.
- Resolves as an include in OMG.
- Resolved **relative to the referencing document** (standard Markdown link semantics) — unlike `@name` / `{{> name }}`, which look up a logical name under `partials/`. This is what makes the same reference clickable.
- Tagged via a new `kind: 'logical' | 'path'` field on `PartialRef`.
- Excluded from the parsed `description`; ignored inside fenced code blocks.

### `fmt` emits `// no response body` (Closes #122)

`omg fmt` now inserts a `// no response body` comment into empty response blocks (`omg.response`, `omg.response.{code}`, `omg.response.default`):

```omg.response.401
// no response body
```

- Applies only to response blocks with an empty/whitespace body.
- Idempotent — a comment-only block formats unchanged.
- Compiled output is unchanged (empty body and comment-only body both mean no response schema).

## Tests

- New `formatter.test.ts` (empty-block injection, idempotency, non-response blocks untouched).
- New parser tests (link detection, `kind` tagging, code-block exclusion, description exclusion).
- New resolver tests (document-relative resolution, path-aware missing-partial error).
- Verified end-to-end with the CLI: a link-partial's blocks inline correctly and an empty `omg.response.201` still compiles to a `201` response.

## Docs

- `docusaurus/docs/syntax/partials.md`, `grammar/omg.peg`, omg skill, and `CHANGELOG.md` updated.

Note: did **not** run `fmt -w` over `examples/` — those files have pre-existing formatting drift, so it would have churned 357 files of unrelated reformatting. Left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)