### PR TITLE
ci: auto-merge green Dependabot patch/minor PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-merge
+# Auto-merges Dependabot patch & minor PRs once required CI checks pass.
+# Majors fall through and wait for manual review.
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for patch & minor
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/dependabot-automerge.yml`: Dependabot patch & minor PRs auto-merge once required CI passes; majors wait for manual review. Merge commit, not squash. Companion: branch protection on the default branch requiring this repo's existing checks (admins bypass, no required reviews).

🤖 Generated with [Claude Code](https://claude.com/claude-code)